### PR TITLE
`tag_name` => `tag`

### DIFF
--- a/src/main/utils/binary.js
+++ b/src/main/utils/binary.js
@@ -86,7 +86,7 @@ export const getURL = async () => {
 
   return {
     url: downloadURL,
-    version: response.tag_name
+    version: response.tag
   }
 }
 


### PR DESCRIPTION
`response.tag_name === undefined` evals to  `true`, since there's no `tag_name` on https://now-cli-latest.now.sh/ 😅 That said, the binary is not being auto updated 😮 