### PR TITLE
Use lint-staged with `--fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean": "chmod u+x dist && rm -rf node_modules app/node_modules dist app/dist",
     "build": "cross-env NODE_ENV=production webpack",
     "lint": "xo",
-    "precommit": "npm run lint",
+    "precommit": "lint-staged",
     "test": "npm run dist && npm run lint && ava",
     "pack": "npm run build && build --dir",
     "dist": "npm run build && build"
@@ -21,6 +21,12 @@
         "squirrel"
       ]
     }
+  },
+  "lint-staged": {
+    "*.js": [
+      "xo --fix",
+      "git add"
+    ]
   },
   "xo": {
     "extends": "xo-react",
@@ -64,6 +70,7 @@
     "eslint-plugin-react": "6.9.0",
     "husky": "0.13.1",
     "json-loader": "0.5.4",
+    "lint-staged": "3.3.1",
     "postcss-import": "9.1.0",
     "postcss-loader": "1.3.0",
     "raw-loader": "0.5.1",


### PR DESCRIPTION
Instead of linting all files in the pre-commit hook, 🚫💩 [lint-staged](https://github.com/okonet/lint-staged) is running linters only on staged files. This leads to a huge performance improvement and also more relevant lint results (only files that are gonna end up in the commit will be linted).

See https://medium.com/@okonetchnikov/make-linting-great-again-f3890e1ad6b8#.72r8egtix for the motivation.