### PR TITLE
Implement serverless next

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -84,7 +84,7 @@ global.startRefresh = async tutorialWindow => {
   );
 };
 
-const windowURL = page => `next://${page}`;
+const windowURL = page => `next://app/${page}`;
 
 const onboarding = () => {
   const win = new BrowserWindow({

--- a/main/server.js
+++ b/main/server.js
@@ -1,10 +1,20 @@
 // Packages
+const fs = require('fs');
 const next = require('next');
 const dev = require('electron-is-dev');
 const { resolve: resolvePath } = require('app-root-path');
 const { Router } = require('@marshallofsound/electron-router');
 
 const router = new Router('next');
+
+const render = require('next/dist/server/render');
+
+render.serveStatic = (req, res, path) => {
+  fs.readFile(path, (err, buffer) => {
+    if (err) return res.notFound();
+    res.send(buffer);
+  });
+};
 
 module.exports = async () => {
   const dir = resolvePath('./renderer');
@@ -13,7 +23,8 @@ module.exports = async () => {
 
   await nextApp.prepare();
 
-  router.use('*', (req, res) => {
+  router.use('app/*', (req, res) => {
+    req.url = req.url.replace(/\/$/, '');
     return nextHandler(req, res);
   });
 };

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@marshallofsound/electron-router": "1.2.3",
+    "@marshallofsound/electron-router": "2.0.0",
     "app-root-path": "2.0.1",
     "async-retry": "0.3.0",
     "chalk": "1.1.3",

--- a/renderer/pages/about.js
+++ b/renderer/pages/about.js
@@ -4,6 +4,7 @@ import { platform } from 'os';
 // Packages
 import React from 'react';
 import timeAgo from 'time-ago';
+import { rendererPreload } from '@marshallofsound/electron-router';
 
 // Vectors
 import CloseWindowSVG from '../vectors/close-window';
@@ -16,6 +17,8 @@ import Licenses from '../components/licenses';
 // Helpers
 import showError from '../utils/error';
 import remote from '../utils/electron';
+
+if (process.type === 'renderer') rendererPreload();
 
 const openLink = event => {
   const link = event.target;

--- a/renderer/pages/tutorial.js
+++ b/renderer/pages/tutorial.js
@@ -4,6 +4,7 @@ import { platform } from 'os';
 // Packages
 import React from 'react';
 import Slider from 'react-slick';
+import { rendererPreload } from '@marshallofsound/electron-router';
 
 // Helpers
 import remote from '../utils/electron';
@@ -20,6 +21,8 @@ import Title from '../components/title';
 import Login from '../components/login';
 import Binary from '../components/binary';
 import Container from '../components/container';
+
+if (process.type === 'renderer') rendererPreload();
 
 const SliderArrows = React.createClass({
   render() {


### PR DESCRIPTION
* Magical `next` server override
* Root hostname of `app`
* Update `electron-router` for Express API compatibility fixes 👍 
* Call `rendererPreload` in all renderer processes 👍 

/cc @leo 