### PR TITLE
Properly handle tray icon clicks on Windows

### DIFF
--- a/main/utils/frames/list.js
+++ b/main/utils/frames/list.js
@@ -3,7 +3,7 @@ const path = require('path')
 const { platform } = require('os')
 
 // Packages
-const { BrowserWindow } = require('electron')
+const electron = require('electron')
 const isDev = require('electron-is-dev')
 const { resolve } = require('app-root-path')
 const debug = require('electron-debug')
@@ -14,9 +14,7 @@ const positionWindow = require('./position')
 
 // Ensure that people can open the developer tools
 // even in production
-debug({
-  enabled: true
-})
+debug({ enabled: true })
 
 const windowURL = page => {
   if (isDev) {
@@ -27,7 +25,7 @@ const windowURL = page => {
 }
 
 exports.tutorialWindow = tray => {
-  const win = new BrowserWindow({
+  const win = new electron.BrowserWindow({
     width: 650,
     height: 430,
     title: 'Welcome to Now',
@@ -73,7 +71,7 @@ exports.tutorialWindow = tray => {
 }
 
 exports.aboutWindow = tray => {
-  const win = new BrowserWindow({
+  const win = new electron.BrowserWindow({
     width: 360,
     height: 408,
     title: 'About Now',
@@ -105,7 +103,7 @@ exports.mainWindow = tray => {
     windowHeight -= 12
   }
 
-  const win = new BrowserWindow({
+  const win = new electron.BrowserWindow({
     width: 330,
     height: windowHeight,
     title: 'Now',
@@ -136,7 +134,22 @@ exports.mainWindow = tray => {
       return
     }
 
-    win.hide()
+    const { screen } = electron
+    const cursor = screen.getCursorScreenPoint()
+    const trayBounds = global.tray.getBounds()
+
+    const x =
+      cursor.x >= trayBounds.x && cursor.x <= trayBounds.x + trayBounds.width
+    const y =
+      cursor.y >= trayBounds.y && cursor.y <= trayBounds.y + trayBounds.height
+
+    // Don't close the window on click on the tray icon
+    // Because that will already toogle the window
+    if (x && y) {
+      return
+    }
+
+    win.close()
   })
 
   return win

--- a/main/utils/frames/list.js
+++ b/main/utils/frames/list.js
@@ -16,7 +16,7 @@ const positionWindow = require('./position')
 debug({ enabled: true })
 
 // Check if Windows
-const isWin = process.platform === 'win32'
+const isWinOS = process.platform === 'win32'
 
 const windowURL = page => {
   if (isDev) {
@@ -101,7 +101,7 @@ exports.aboutWindow = tray => {
 exports.mainWindow = tray => {
   let windowHeight = 380
 
-  if (isWin) {
+  if (isWinOS) {
     windowHeight -= 12
   }
 
@@ -136,7 +136,7 @@ exports.mainWindow = tray => {
       return
     }
 
-    if (!isWin) {
+    if (!isWinOS) {
       win.close()
       return
     }

--- a/main/utils/frames/list.js
+++ b/main/utils/frames/list.js
@@ -138,10 +138,10 @@ exports.mainWindow = tray => {
     const cursor = screen.getCursorScreenPoint()
     const trayBounds = global.tray.getBounds()
 
-    const x =
-      cursor.x >= trayBounds.x && cursor.x <= trayBounds.x + trayBounds.width
-    const y =
-      cursor.y >= trayBounds.y && cursor.y <= trayBounds.y + trayBounds.height
+    const xAfter = cursor.x <= trayBounds.x + trayBounds.width
+    const x = cursor.x >= trayBounds.x && xAfter
+    const yAfter = trayBounds.y + trayBounds.height
+    const y = cursor.y >= trayBounds.y && cursor.y <= yAfter
 
     // Don't close the window on click on the tray icon
     // Because that will already toogle the window

--- a/main/utils/frames/list.js
+++ b/main/utils/frames/list.js
@@ -1,6 +1,5 @@
 // Native
 const path = require('path')
-const { platform } = require('os')
 
 // Packages
 const electron = require('electron')
@@ -15,6 +14,9 @@ const positionWindow = require('./position')
 // Ensure that people can open the developer tools
 // even in production
 debug({ enabled: true })
+
+// Check if Windows
+const isWin = process.platform === 'win32'
 
 const windowURL = page => {
   if (isDev) {
@@ -99,7 +101,7 @@ exports.aboutWindow = tray => {
 exports.mainWindow = tray => {
   let windowHeight = 380
 
-  if (platform() === 'win32') {
+  if (isWin) {
     windowHeight -= 12
   }
 
@@ -131,6 +133,11 @@ exports.mainWindow = tray => {
   // Otherwise, we won't be able to debug the renderer
   win.on('blur', () => {
     if (win.webContents.isDevToolsOpened()) {
+      return
+    }
+
+    if (!isWin) {
+      win.close()
       return
     }
 

--- a/main/utils/frames/toggle.js
+++ b/main/utils/frames/toggle.js
@@ -1,16 +1,23 @@
 const positionWindow = require('./position')
 
 module.exports = (event, window, tray) => {
-  // Check if the current window is visible
-  const visible = window.isVisible()
+  const isVisible = window.isVisible()
+  const isWin = process.platform === 'win32'
+  const isMain = global.windows && window === global.windows.main
 
   if (event) {
     // Don't open the menu
     event.preventDefault()
   }
 
+  let checkFocus = true
+
+  if (isWin && isMain) {
+    checkFocus = false
+  }
+
   // If window open and not focused, bring it to focus
-  if (visible && !window.isFocused()) {
+  if (checkFocus && isVisible && !window.isFocused()) {
     window.focus()
     return
   }
@@ -18,12 +25,13 @@ module.exports = (event, window, tray) => {
   // Show or hide onboarding window
   // Calling `.close()` will actually make it
   // hide, but it's a special scenario which we're
-  // listening for in a different place
-  if (visible) {
+  // listening for in a different// If the "blur" event was triggered when
+  // clicking on the tray icon, don't do anything place
+  if (isVisible) {
     window.close()
   } else {
     // Position main window correctly under the tray icon
-    if (global.windows && window === global.windows.main) {
+    if (isMain) {
       positionWindow(tray, window)
     }
 

--- a/main/utils/frames/toggle.js
+++ b/main/utils/frames/toggle.js
@@ -10,14 +10,8 @@ module.exports = (event, window, tray) => {
     event.preventDefault()
   }
 
-  let checkFocus = true
-
-  if (isWin && isMain) {
-    checkFocus = false
-  }
-
   // If window open and not focused, bring it to focus
-  if (checkFocus && isVisible && !window.isFocused()) {
+  if (!isWin && isVisible && !window.isFocused()) {
     window.focus()
     return
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "now-desktop",
   "version": "2.2.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@types/node": {
       "version": "7.0.33",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
     "env": [
       "browser",
       "node"
-    ]
+    ],
+    "rules": {
+      "linebreak-style": 0
+    }
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Previously, the main windows opened twice when clicking on the tray icon. Fixed now!

This fixes #318.