### PR TITLE
Don't show location of login events if it's not defined

### DIFF
--- a/renderer/components/feed/messages/login.js
+++ b/renderer/components/feed/messages/login.js
@@ -36,6 +36,7 @@ export default class Login extends Message {
     }
 
     let message = 'logged in'
+
     if (from) message += ` from ${from}`
     if (os) message += ` (${os})`
 
@@ -48,6 +49,16 @@ export default class Login extends Message {
         typeof geolocation.most_specific_subdivision === 'object'
           ? geolocation.most_specific_subdivision.names.en
           : geolocation.regionName
+
+      // Only output location if both city and region are specified
+      if (!city || !region) {
+        return (
+          <p>
+            <b>You</b> {message}
+          </p>
+        )
+      }
+
       if (city === region) {
         message += ` in ${city}`
       } else {


### PR DESCRIPTION
BEFORE

<img width="395" alt="screen shot 2017-07-11 at 16 32 51" src="https://user-images.githubusercontent.com/6170607/28073840-440afccc-6657-11e7-9ef4-45f2840d43ff.png">

AFTER

<img width="410" alt="screen shot 2017-07-11 at 16 36 16" src="https://user-images.githubusercontent.com/6170607/28073851-4a4a90b6-6657-11e7-9d74-c9516d6b6775.png">

The location sometimes isn't specified in the event payload, so we shouldn't show it in these cases!