### PR TITLE
Don't open automatically after update

### DIFF
--- a/main/updates.js
+++ b/main/updates.js
@@ -13,6 +13,7 @@ const isDev = require('electron-is-dev')
 // Ours
 const notify = require('./notify')
 const binaryUtils = require('./utils/binary')
+const { saveConfig } = require('./utils/config')
 
 const platform = process.platform === 'darwin' ? 'osx' : process.platform
 const feedURL = 'https://now-desktop-releases.zeit.sh/update/' + platform
@@ -142,6 +143,15 @@ const startAppUpdates = () => {
         return
       }
 
+      // Don't open the main window after re-opening
+      // the app for this update
+      saveConfig({
+        desktop: {
+          updated: true
+        }
+      })
+
+      // Then restart the application
       autoUpdater.quitAndInstall()
       app.quit()
     }, ms('2s'))


### PR DESCRIPTION
By default, the event feed opens every time you start the app. This shouldn't happen on app update, because it makes people notice that we triggered an update - it should be silent.

Sadly, electron provides no native way of checking if the app was opened after an update (asked the electron guys on the community slack of theirs), so we have to temporarily write to config. This also allows us to open the app silently from other places.

This closes #315.