### PR TITLE
Don't use Yarn to install packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,7 @@
       "ps": "Install-Product node 6 x64"
     },
     "set CI=true",
-    "npm -g install npm@latest",
-    "yarn"
+    "npm install"
   ],
   "build": false,
   "shallow_clone": true,


### PR DESCRIPTION
Because we have `package-lock.json`, npm is faster!