### PR TITLE
Tweaked app updates

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -83,10 +83,6 @@ if (!isDev && firstRun()) {
 // Within the bundled app, the path would otherwise be different
 fixPath()
 
-// Keep track of the app's busyness for telling
-// the autoupdater if it can restart the application
-process.env.BUSYNESS = 'ready'
-
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()

--- a/main/menu.js
+++ b/main/menu.js
@@ -1,7 +1,7 @@
 // Packages
 const { Menu, shell } = require('electron')
 
-// Ours
+// Utilities
 const logout = require('./utils/logout')
 const toggleWindow = require('./utils/frames/toggle')
 const { getConfig } = require('./utils/config')

--- a/main/updates.js
+++ b/main/updates.js
@@ -131,7 +131,10 @@ const startAppUpdates = () => {
     autoUpdater.checkForUpdates()
   }
 
-  // And then every 15 minutes
+  // Check for updates every 15 minutes
+  // We won't to this an launch because it might
+  // trigger an error loop, since the app is
+  // able to quit and install by itself
   setInterval(checkForUpdates, ms('15m'))
 
   autoUpdater.on('update-downloaded', () => {

--- a/main/updates.js
+++ b/main/updates.js
@@ -139,10 +139,6 @@ const startAppUpdates = () => {
     process.env.UPDATE_STATUS = 'downloaded'
 
     setInterval(() => {
-      if (process.env.BUSYNESS !== 'ready') {
-        return
-      }
-
       // Don't open the main window after re-opening
       // the app for this update
       saveConfig({

--- a/main/updates.js
+++ b/main/updates.js
@@ -10,7 +10,7 @@ const exists = require('path-exists')
 const { exec } = require('child-process-promise')
 const isDev = require('electron-is-dev')
 
-// Ours
+// Utilities
 const notify = require('./notify')
 const binaryUtils = require('./utils/binary')
 const { saveConfig } = require('./utils/config')

--- a/main/updates.js
+++ b/main/updates.js
@@ -131,9 +131,6 @@ const startAppUpdates = () => {
     autoUpdater.checkForUpdates()
   }
 
-  // Check for app update after startup
-  setTimeout(checkForUpdates, ms('10s'))
-
   // And then every 5 minutes
   setInterval(checkForUpdates, ms('5m'))
 

--- a/main/updates.js
+++ b/main/updates.js
@@ -147,7 +147,6 @@ const startAppUpdates = () => {
 
       // Then restart the application
       autoUpdater.quitAndInstall()
-      app.quit()
     }, ms('2s'))
   })
 

--- a/main/updates.js
+++ b/main/updates.js
@@ -136,8 +136,6 @@ const startAppUpdates = () => {
   setInterval(checkForUpdates, ms('5m'))
 
   autoUpdater.on('update-downloaded', () => {
-    process.env.UPDATE_STATUS = 'downloaded'
-
     setInterval(() => {
       // Don't open the main window after re-opening
       // the app for this update

--- a/main/updates.js
+++ b/main/updates.js
@@ -14,6 +14,7 @@ const isDev = require('electron-is-dev')
 const notify = require('./notify')
 const binaryUtils = require('./utils/binary')
 const { saveConfig } = require('./utils/config')
+const handleException = require('./utils/exception')
 
 const platform = process.platform === 'darwin' ? 'osx' : process.platform
 const feedURL = 'https://now-desktop-releases.zeit.sh/update/' + platform
@@ -115,7 +116,8 @@ const startBinaryUpdates = () => {
 }
 
 const startAppUpdates = () => {
-  autoUpdater.on('error', console.error)
+  // Report auto update errors to Slack
+  autoUpdater.on('error', error => handleException(error, false))
 
   try {
     autoUpdater.setFeedURL(feedURL + '/' + app.getVersion())

--- a/main/updates.js
+++ b/main/updates.js
@@ -131,8 +131,8 @@ const startAppUpdates = () => {
     autoUpdater.checkForUpdates()
   }
 
-  // And then every 5 minutes
-  setInterval(checkForUpdates, ms('5m'))
+  // And then every 15 minutes
+  setInterval(checkForUpdates, ms('15m'))
 
   autoUpdater.on('update-downloaded', () => {
     setInterval(() => {

--- a/main/updates.js
+++ b/main/updates.js
@@ -149,6 +149,7 @@ const startAppUpdates = () => {
 
       // Then restart the application
       autoUpdater.quitAndInstall()
+      app.quit()
     }, ms('2s'))
   })
 

--- a/main/updates.js
+++ b/main/updates.js
@@ -132,7 +132,7 @@ const startAppUpdates = () => {
   }
 
   // Check for updates every 15 minutes
-  // We won't to this an launch because it might
+  // We won't do this an launch because it might
   // trigger an error loop, since the app is
   // able to quit and install by itself
   setInterval(checkForUpdates, ms('15m'))

--- a/main/utils/deploy/get-files.js
+++ b/main/utils/deploy/get-files.js
@@ -8,7 +8,7 @@ const ignore = require('ignore')
 const _glob = require('glob')
 const { stat, lstat, readdir, readFile } = require('fs-extra')
 
-// Ours
+// Utilities
 const IGNORED = require('./ignored')
 
 const glob = async function(pattern, options) {

--- a/main/utils/deploy/index.js
+++ b/main/utils/deploy/index.js
@@ -433,7 +433,6 @@ module.exports = async dir => {
     throw new Error("Path doesn't exist!")
   }
 
-  process.env.BUSYNESS = 'deploying'
   const loadingPlan = getPlan()
 
   let deploymentType

--- a/main/utils/exception.js
+++ b/main/utils/exception.js
@@ -9,7 +9,7 @@ const fetch = require('node-fetch')
 // Utilities
 const userAgent = require('./user-agent')
 
-module.exports = async error => {
+module.exports = async (error, relaunch = true) => {
   // Make the error sendable using GET
   const errorParts = serializeError(error)
 
@@ -30,8 +30,10 @@ module.exports = async error => {
     })
   } catch (err) {}
 
-  // Restart the app, so that it doesn't continue
-  // running in a broken state
-  app.relaunch()
-  app.exit(0)
+  if (relaunch) {
+    // Restart the app, so that it doesn't continue
+    // running in a broken state
+    app.relaunch()
+    app.exit(0)
+  }
 }

--- a/main/utils/frames/toggle.js
+++ b/main/utils/frames/toggle.js
@@ -1,3 +1,4 @@
+// Utilities
 const positionWindow = require('./position')
 
 module.exports = (event, window, tray) => {

--- a/main/utils/highlight.js
+++ b/main/utils/highlight.js
@@ -50,9 +50,6 @@ module.exports = (win, tray) => {
         return
       }
 
-      // Record busyness for auto updater
-      process.env.BUSYNESS = highlighted ? 'window-open' : 'ready'
-
       // Highlight the tray or don't
       tray.setHighlightMode(highlighted ? 'always' : 'selection')
     })

--- a/main/utils/user-agent.js
+++ b/main/utils/user-agent.js
@@ -1,7 +1,7 @@
 // Native
 const os = require('os')
 
-// Ours
+// Utilities
 const { version } = require('../../package')
 
 module.exports = `now-desktop ${version} node-${process.version} ${os.platform()} (${os.arch()})`


### PR DESCRIPTION
There might be scenarios in which Electron's native auto updater isn't able to move an update into place and therefore triggers an error loop. This PR ensures that we're avoiding this by checking for updates less often, not checking for updates on launch and removing various global states.

Once this PR is rolled out, we'll also receive errors thrown by the auto updater directly in Slack and are therefore able to report any possible problems to the Electron team specifically.

Fixes https://github.com/zeit/now-desktop/issues/331