### PR TITLE
Introduced new URL for updates

### DIFF
--- a/main/updates.js
+++ b/main/updates.js
@@ -17,8 +17,8 @@ const notify = require('./notify')
 const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
-const platform = process.platform === 'darwin' ? 'osx' : process.platform
-const feedURL = 'https://now-desktop-releases.zeit.sh/update/' + platform
+const { platform } = process
+const feedURL = `https://now-desktop-releases.zeit.sh/update/${platform}`
 
 const localBinaryVersion = async () => {
   // We need to modify the `cwd` to prevent the app itself (Now.exe) to be


### PR DESCRIPTION
I deployed a [new update server](https://github.com/zeit/hazel) that's much faster and more lightweight. It also scales very nicely across multiple instances, which is the most important feature.