### PR TITLE
Added event groups like on the dashboard

### DIFF
--- a/renderer/components/feed/none.js
+++ b/renderer/components/feed/none.js
@@ -6,6 +6,9 @@ import { bool } from 'prop-types'
 // Styles
 import styles from '../../styles/components/feed/none'
 
+// Vectors
+import FilterIcon from '../../vectors/filter'
+
 const openDocs = event => {
   event.preventDefault()
   const remote = electron.remote || false
@@ -18,7 +21,13 @@ const openDocs = event => {
 const NoEvents = ({ filtered }) =>
   <div>
     {filtered
-      ? <h1>No Events Found!</h1>
+      ? [
+          <h1 key="heading">No Events Found!</h1>,
+          <p key="description">
+            You can pick a different category of events using the{' '}
+            <FilterIcon background="#F5F5F5" /> filter on the top.
+          </p>
+        ]
       : [
           <h1 key="heading">No Activity to Show!</h1>,
           <p key="description">

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -13,6 +13,7 @@ import styles from '../styles/components/title'
 // Components
 import Done from '../vectors/done'
 import Deploy from '../vectors/deploy'
+import Filter from '../vectors/filter'
 import Search from './feed/search'
 
 class Title extends React.PureComponent {
@@ -95,6 +96,11 @@ class Title extends React.PureComponent {
           <h1>
             {this.props.children}
           </h1>
+
+          {this.props.light &&
+            <span className="filter">
+              <Filter />
+            </span>}
 
           {this.props.light &&
             <span

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -20,7 +20,11 @@ class Title extends React.PureComponent {
   constructor(props) {
     super(props)
 
-    this.state = { updateMessage: false }
+    this.state = {
+      updateMessage: false,
+      typeFilter: false
+    }
+
     this.setReference = setRef.bind(this)
 
     this.selectToDeploy = this.selectToDeploy.bind(this)
@@ -113,7 +117,7 @@ class Title extends React.PureComponent {
             </span>}
         </div>
 
-        <section>
+        <section className="update-message">
           <Done />
           <p>Context updated for now CLI!</p>
         </section>

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -80,15 +80,25 @@ class Title extends React.PureComponent {
 
   renderTypeFilter() {
     const types = ['Me', 'Team', 'System']
+    const { isUser } = this.props
+    const { filteredType } = this.state
+
+    if (isUser) {
+      types.splice(1, 1)
+    }
 
     return (
       <section className="filter">
         <nav>
-          {types.map(item => {
+          {types.map((item, index) => {
             const classes = []
             const handle = item.toLowerCase()
 
-            if (this.state.filteredType === handle) {
+            if (filteredType === handle) {
+              classes.push('active')
+            }
+
+            if (isUser && filteredType === 'team' && index === 0) {
               classes.push('active')
             }
 
@@ -183,7 +193,8 @@ Title.propTypes = {
   setFilter: PropTypes.func,
   setSearchRef: PropTypes.func,
   searchShown: PropTypes.bool,
-  setTypeFilter: PropTypes.func
+  setTypeFilter: PropTypes.func,
+  isUser: PropTypes.bool
 }
 
 export default Title

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -119,7 +119,7 @@ class Title extends React.PureComponent {
 
         <section className="update-message">
           <Done />
-          <p>Context updated for now CLI!</p>
+          <p>Context updated for Now CLI!</p>
         </section>
 
         <style jsx>

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -78,6 +78,18 @@ class Title extends React.PureComponent {
     }, 2000)
   }
 
+  updateTypeFilter(type) {
+    const { setTypeFilter } = this.props
+
+    if (setTypeFilter) {
+      setTypeFilter(type)
+    }
+
+    console.log(type)
+
+    this.setState({ filteredType: type })
+  }
+
   renderTypeFilter() {
     const types = ['Me', 'Team', 'System']
     const { isUser } = this.props
@@ -103,7 +115,11 @@ class Title extends React.PureComponent {
             }
 
             return (
-              <a className={classes.join(' ')} key={item}>
+              <a
+                className={classes.join(' ')}
+                key={item}
+                onClick={this.updateTypeFilter.bind(this, handle)}
+              >
                 {item}
               </a>
             )

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -85,8 +85,6 @@ class Title extends React.PureComponent {
       setTypeFilter(type)
     }
 
-    console.log(type)
-
     this.setState({ filteredType: type })
   }
 

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -79,6 +79,10 @@ class Title extends React.PureComponent {
   }
 
   updateTypeFilter(type) {
+    if (type === this.state.filteredType) {
+      return
+    }
+
     const { setTypeFilter } = this.props
 
     if (setTypeFilter) {

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -22,7 +22,8 @@ class Title extends React.PureComponent {
 
     this.state = {
       updateMessage: false,
-      typeFilter: false
+      typeFilter: false,
+      filteredType: 'team'
     }
 
     this.setReference = setRef.bind(this)
@@ -75,6 +76,35 @@ class Title extends React.PureComponent {
         updateMessage: false
       })
     }, 2000)
+  }
+
+  renderTypeFilter() {
+    const types = ['Me', 'Team', 'System']
+
+    return (
+      <section className="filter">
+        <nav>
+          {types.map(item => {
+            const classes = []
+            const handle = item.toLowerCase()
+
+            if (this.state.filteredType === handle) {
+              classes.push('active')
+            }
+
+            return (
+              <a className={classes.join(' ')} key={item}>
+                {item}
+              </a>
+            )
+          })}
+        </nav>
+
+        <style jsx>
+          {styles}
+        </style>
+      </section>
+    )
   }
 
   render() {
@@ -134,15 +164,7 @@ class Title extends React.PureComponent {
           <p>Context updated for Now CLI!</p>
         </section>
 
-        <section className="filter">
-          <nav>
-            <a href="#" className="active">
-              Me
-            </a>
-            <a href="#">Team</a>
-            <a href="#">System</a>
-          </nav>
-        </section>
+        {this.renderTypeFilter()}
 
         <style jsx>
           {styles}
@@ -160,7 +182,8 @@ Title.propTypes = {
   light: PropTypes.bool,
   setFilter: PropTypes.func,
   setSearchRef: PropTypes.func,
-  searchShown: PropTypes.bool
+  searchShown: PropTypes.bool,
+  setTypeFilter: PropTypes.func
 }
 
 export default Title

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -113,6 +113,7 @@ class Title extends React.PureComponent {
           </h1>
 
           {this.props.light &&
+            this.props.searchShown &&
             <span className="toggle-filter" onClick={this.toggleFilter}>
               <Filter />
             </span>}

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -30,6 +30,7 @@ class Title extends React.PureComponent {
     this.selectToDeploy = this.selectToDeploy.bind(this)
     this.hideDeployIcon = this.hideDeployIcon.bind(this)
     this.showDeployIcon = this.showDeployIcon.bind(this)
+    this.toggleFilter = this.toggleFilter.bind(this)
   }
 
   componentDidMount() {
@@ -52,6 +53,12 @@ class Title extends React.PureComponent {
 
   showDeployIcon() {
     this.deployIcon.classList.remove('hidden')
+  }
+
+  toggleFilter() {
+    this.setState({
+      typeFilter: !this.state.typeFilter
+    })
   }
 
   scopeUpdated() {
@@ -85,6 +92,10 @@ class Title extends React.PureComponent {
       classes.push('scope-updated')
     }
 
+    if (this.state.typeFilter) {
+      classes.push('filter-visible')
+    }
+
     return (
       <aside className={classes.join(' ')}>
         <div>
@@ -102,7 +113,7 @@ class Title extends React.PureComponent {
           </h1>
 
           {this.props.light &&
-            <span className="filter">
+            <span className="toggle-filter" onClick={this.toggleFilter}>
               <Filter />
             </span>}
 
@@ -120,6 +131,14 @@ class Title extends React.PureComponent {
         <section className="update-message">
           <Done />
           <p>Context updated for Now CLI!</p>
+        </section>
+
+        <section className="filter">
+          <nav>
+            <a href="#">Me</a>
+            <a href="#">Team</a>
+            <a href="#">System</a>
+          </nav>
         </section>
 
         <style jsx>

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -136,7 +136,9 @@ class Title extends React.PureComponent {
 
         <section className="filter">
           <nav>
-            <a href="#">Me</a>
+            <a href="#" className="active">
+              Me
+            </a>
             <a href="#">Team</a>
             <a href="#">System</a>
           </nav>

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -595,7 +595,14 @@ class Feed extends React.Component {
   }
 
   render() {
+    let isUser = false
+
     const activeScope = this.detectScope('id', this.state.scope)
+    const { currentUser } = this.state
+
+    if (currentUser && activeScope && activeScope.id === currentUser.uid) {
+      isUser = true
+    }
 
     return (
       <main>
@@ -609,6 +616,7 @@ class Feed extends React.Component {
             light
             name="title"
             searchShown={Boolean(activeScope)}
+            isUser={isUser}
           >
             {activeScope ? activeScope.name : 'Now'}
           </Title>

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -49,7 +49,8 @@ class Feed extends React.Component {
       currentUser: null,
       teams: [],
       eventFilter: null,
-      online: true
+      online: true,
+      typeFilter: 'team'
     }
 
     this.remote = electron.remote || false
@@ -320,21 +321,19 @@ class Feed extends React.Component {
   }
 
   setOnlineState() {
-    this.setState({
-      online: navigator.onLine
-    })
+    this.setState({ online: navigator.onLine })
   }
 
   showDropZone() {
-    this.setState({
-      dropZone: true
-    })
+    this.setState({ dropZone: true })
   }
 
   hideDropZone() {
-    this.setState({
-      dropZone: false
-    })
+    this.setState({ dropZone: false })
+  }
+
+  setTypeFilter(type) {
+    this.setState({ typeFilter: type })
   }
 
   setScope(scope) {

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -382,7 +382,8 @@ class Feed extends React.Component {
   }
 
   filterEvents(list, scopedTeam) {
-    const { eventFilter, typeFilter, currentUser } = this.state
+    let { eventFilter, typeFilter, currentUser } = this.state
+
     const filtering = Boolean(eventFilter)
     const HTML = parseHTML.Parser
 
@@ -404,6 +405,10 @@ class Feed extends React.Component {
       }
 
       item.message = <MessageComponent {...args} />
+
+      if (typeFilter === 'team' && !item.user) {
+        typeFilter = 'me'
+      }
 
       if (eventSortedOut(typeFilter, item, currentUser)) {
         return false

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -29,6 +29,7 @@ import messageComponents from '../components/feed/messages'
 // Utilities
 import loadData from '../utils/data/load'
 import { API_EVENTS } from '../utils/data/endpoints'
+import eventSortedOut from '../utils/filter-event'
 
 // Styles
 import {
@@ -66,6 +67,7 @@ class Feed extends React.Component {
     this.setScope = this.setScope.bind(this)
     this.setOnlineState = this.setOnlineState.bind(this)
     this.setScopeWithSlug = this.setScopeWithSlug.bind(this)
+    this.setTypeFilter = this.setTypeFilter.bind(this)
 
     // Ensure that we're not loading events again
     this.loading = new Set()
@@ -380,7 +382,8 @@ class Feed extends React.Component {
   }
 
   filterEvents(list, scopedTeam) {
-    const filtering = Boolean(this.state.eventFilter)
+    const { eventFilter, typeFilter, currentUser } = this.state
+    const filtering = Boolean(eventFilter)
     const HTML = parseHTML.Parser
 
     let keywords = null
@@ -401,6 +404,10 @@ class Feed extends React.Component {
       }
 
       item.message = <MessageComponent {...args} />
+
+      if (eventSortedOut(typeFilter, item, currentUser)) {
+        return false
+      }
 
       if (filtering) {
         let markup = renderToStaticMarkup(item.message)
@@ -616,6 +623,7 @@ class Feed extends React.Component {
             name="title"
             searchShown={Boolean(activeScope)}
             isUser={isUser}
+            setTypeFilter={this.setTypeFilter}
           >
             {activeScope ? activeScope.name : 'Now'}
           </Title>

--- a/renderer/styles/components/feed/search.js
+++ b/renderer/styles/components/feed/search.js
@@ -6,7 +6,6 @@ export default `
     bottom: 0;
     display: flex;
     width: 100%;
-    z-index: -200;
   }
 
   span {

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -58,7 +58,8 @@ export default `
   }
 
   .light .toggle-filter:hover,
-  .light .deploy:hover {
+  .light .deploy:hover,
+  .filter-visible .toggle-filter {
     opacity: 1;
   }
 
@@ -135,6 +136,7 @@ export default `
     flex: 1;
     text-align: center;
     padding: 3px 0;
+    cursor: default;
   }
 
   .filter a:nth-child(1) {

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -56,9 +56,14 @@ export default `
     transition: opacity .2s ease;
   }
 
+  .light .toggle-filter {
+    opacity: 0.35;
+    right: 36px;
+  }
+
   .light .toggle-filter:hover,
   .light .deploy:hover,
-  .filter-visible .toggle-filter {
+  .light.filter-visible .toggle-filter {
     opacity: 1;
   }
 
@@ -69,11 +74,6 @@ export default `
 
   .light .deploy.hidden {
     opacity: 0;
-  }
-
-  .light .toggle-filter {
-    opacity: 0.35;
-    right: 36px;
   }
 
   .windows {

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -139,6 +139,10 @@ export default `
     cursor: default;
   }
 
+  .filter a.active {
+    color: #000;
+  }
+
   .filter a:nth-child(1) {
     border-right: 1px solid #EAEAEA;
   }

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -31,6 +31,7 @@ export default `
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
     flex-shrink: 0;
+    display: block;
   }
 
   .light h1 {
@@ -73,7 +74,7 @@ export default `
     border-radius: 0;
   }
 
-  section {
+  .update-message {
     opacity: 0;
     transition: opacity .8s ease;
     position: absolute;
@@ -87,18 +88,28 @@ export default `
     display: flex;
     padding-left: 17px;
     pointer-events: none;
+    height: 35px;
   }
 
-  section p {
+  .update-message p {
     margin-left: 12px;
   }
 
-  .scope-updated section {
+  .scope-updated .update-message {
     opacity: 1;
   }
 
   div {
     transition: opacity .5s ease;
+  }
+
+  .light div {
+    height: 36px;
+    width: 100vw;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .scope-updated div {

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -14,6 +14,10 @@ export default `
     cursor: default;
   }
 
+  aside.filter-visible {
+    height: auto;
+  }
+
   h1 {
     margin: 0;
     color: #000000;
@@ -40,7 +44,7 @@ export default `
     font-weight: 600;
   }
 
-  .light .filter,
+  .light .toggle-filter,
   .light .deploy {
     position: absolute;
     height: 36px;
@@ -53,7 +57,7 @@ export default `
     transition: opacity .2s ease;
   }
 
-  .light .filter:hover,
+  .light .toggle-filter:hover,
   .light .deploy:hover {
     opacity: 1;
   }
@@ -66,7 +70,7 @@ export default `
     opacity: 0;
   }
 
-  .light .filter {
+  .light .toggle-filter {
     right: 36px;
   }
 
@@ -114,5 +118,42 @@ export default `
 
   .scope-updated div {
     opacity: 0;
+  }
+
+  .filter {
+    display: none;
+    justify-content: center;
+    padding-bottom: 16px;
+    padding-top: 5px;
+  }
+
+  .filter a {
+    color: #999999;
+    text-decoration: none;
+    font-size: 11px;
+    display: block;
+    flex: 1;
+    text-align: center;
+    padding: 3px 0;
+  }
+
+  .filter a:nth-child(1) {
+    border-right: 1px solid #EAEAEA;
+  }
+
+  .filter a:nth-child(3) {
+    border-left: 1px solid #EAEAEA;
+  }
+
+  .filter nav {
+    border: 1px solid #EAEAEA;
+    display: flex;
+    border-radius: 3px;
+    width: 190px;
+    justify-content: space-between;
+  }
+
+  .filter-visible .filter {
+    display: flex;
   }
 `

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -39,11 +39,11 @@ export default `
     font-weight: 600;
   }
 
+  .light .filter,
   .light .deploy {
     position: absolute;
     height: 36px;
     width: 36px;
-    right: 0;
     top: 0;
     display: flex;
     justify-content: center;
@@ -52,12 +52,21 @@ export default `
     transition: opacity .2s ease;
   }
 
+  .light .filter:hover,
   .light .deploy:hover {
     opacity: 1;
   }
 
+  .light .deploy {
+    right: 0;
+  }
+
   .light .deploy.hidden {
     opacity: 0;
+  }
+
+  .light .filter {
+    right: 36px;
   }
 
   .windows {

--- a/renderer/styles/components/title.js
+++ b/renderer/styles/components/title.js
@@ -53,7 +53,6 @@ export default `
     display: flex;
     justify-content: center;
     align-items: center;
-    opacity: .5;
     transition: opacity .2s ease;
   }
 
@@ -64,6 +63,7 @@ export default `
   }
 
   .light .deploy {
+    opacity: .5;
     right: 0;
   }
 
@@ -72,6 +72,7 @@ export default `
   }
 
   .light .toggle-filter {
+    opacity: 0.35;
     right: 36px;
   }
 

--- a/renderer/utils/filter-event.js
+++ b/renderer/utils/filter-event.js
@@ -1,0 +1,25 @@
+const systemEvents = ['deployment-unfreeze', 'deployment-freeze', 'scale-auto']
+
+const getEventGroup = (item, currentUser) => {
+  if (systemEvents.includes(item.type)) {
+    return 'system'
+  }
+
+  if (currentUser.uid === item.user.uid) {
+    return 'me'
+  }
+
+  return 'team'
+}
+
+module.exports = (typeFilter, item, currentUser) => {
+  const eventGroup = getEventGroup(item, currentUser)
+
+  if (typeFilter === 'team') {
+    return eventGroup !== 'me' && eventGroup !== 'team'
+  }
+
+  // Hand back whether or not it need to
+  // be removed from the list
+  return typeFilter !== eventGroup
+}

--- a/renderer/utils/filter-event.js
+++ b/renderer/utils/filter-event.js
@@ -5,7 +5,7 @@ const getEventGroup = (item, currentUser) => {
     return 'system'
   }
 
-  if (currentUser.uid === item.user.uid) {
+  if (!item.user || currentUser.uid === item.user.uid) {
     return 'me'
   }
 

--- a/renderer/vectors/filter.js
+++ b/renderer/vectors/filter.js
@@ -1,37 +1,60 @@
 // Packages
 import React from 'react'
+import { string } from 'prop-types'
 
-const Filter = () =>
-  <svg
-    width="17px"
-    height="13px"
-    viewBox="0 0 17 13"
-    version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlnsXlink="http://www.w3.org/1999/xlink"
-  >
-    <g
-      id="2.5-Filters"
-      stroke="none"
-      strokeWidth={1}
-      fill="none"
-      fillRule="evenodd"
+const Filter = ({ background }) => {
+  const bgFill = background || '#FFF'
+
+  const props = {
+    width: '17px',
+    height: '13px'
+  }
+
+  if (background) {
+    props.height = '11px'
+    props.width = '15px'
+
+    props.style = {
+      margin: '0 1px -1px 2px'
+    }
+  }
+
+  return (
+    <svg
+      {...props}
+      viewBox="0 0 17 13"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
     >
       <g
-        id="Now-Desktop"
-        transform="translate(-408.000000, -110.000000)"
-        stroke="#000"
+        id="2.5-Filters"
+        stroke="none"
+        strokeWidth={1}
+        fill="none"
+        fillRule="evenodd"
       >
-        <g id="App" transform="translate(79.000000, 54.000000)">
-          <g id="Filters-Icon" transform="translate(329.000000, 57.000000)">
-            <path d="M16.5,8.5 L0.5,8.5" id="Line" strokeLinecap="square" />
-            <path d="M16.5,2.5 L0.5,2.5" id="Line" strokeLinecap="square" />
-            <circle id="Oval" fill="#FFFFFF" cx="5.5" cy="2.5" r="2.5" />
-            <circle id="Oval" fill="#FFFFFF" cx="11.5" cy="8.5" r="2.5" />
+        <g
+          id="Now-Desktop"
+          transform="translate(-408.000000, -110.000000)"
+          stroke="#000"
+        >
+          <g id="App" transform="translate(79.000000, 54.000000)">
+            <g id="Filters-Icon" transform="translate(329.000000, 57.000000)">
+              <path d="M16.5,8.5 L0.5,8.5" id="Line" strokeLinecap="square" />
+              <path d="M16.5,2.5 L0.5,2.5" id="Line" strokeLinecap="square" />
+              <circle id="Oval" fill={bgFill} cx="5.5" cy="2.5" r="2.5" />
+              <circle id="Oval" fill={bgFill} cx="11.5" cy="8.5" r="2.5" />
+            </g>
           </g>
         </g>
       </g>
-    </g>
-  </svg>
+    </svg>
+  )
+}
+
+Filter.propTypes = {
+  background: string
+}
 
 export default Filter

--- a/renderer/vectors/filter.js
+++ b/renderer/vectors/filter.js
@@ -1,0 +1,37 @@
+// Packages
+import React from 'react'
+
+const Filter = () =>
+  <svg
+    width="17px"
+    height="13px"
+    viewBox="0 0 17 13"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    <g
+      id="2.5-Filters"
+      stroke="none"
+      strokeWidth={1}
+      fill="none"
+      fillRule="evenodd"
+    >
+      <g
+        id="Now-Desktop"
+        transform="translate(-408.000000, -110.000000)"
+        stroke="#000"
+      >
+        <g id="App" transform="translate(79.000000, 54.000000)">
+          <g id="Filters-Icon" transform="translate(329.000000, 57.000000)">
+            <path d="M16.5,8.5 L0.5,8.5" id="Line" strokeLinecap="square" />
+            <path d="M16.5,2.5 L0.5,2.5" id="Line" strokeLinecap="square" />
+            <circle id="Oval" fill="#FFFFFF" cx="5.5" cy="2.5" r="2.5" />
+            <circle id="Oval" fill="#FFFFFF" cx="11.5" cy="8.5" r="2.5" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </svg>
+
+export default Filter


### PR DESCRIPTION
After this PR, users will be able to filter the events by three groups (just like on our website).

In addition, I introduced a new feature which ensures that there are always enough events of each event group on the screen (they'll be loaded in the background - max. 30, so that you almost never get to see the "Loading more" banner).

To make this even smoother and faster, we should remove [this limit](https://github.com/zeit/api-events/blob/b39b887df8da0ef0ef31c02768cb56194fc3e72c/lib/get.js#L61). In my opinion, we don't need it anymore, since the event polling cycle is very high.

Here's an example of how the filter UI looks like in default mode:

<img width="459" alt="screen shot 2017-08-23 at 02 57 31" src="https://user-images.githubusercontent.com/6170607/29594095-e9590c46-87ae-11e7-8f4f-0a72b54da8f3.png">

---

This happens when clicking the icon:

<img width="463" alt="screen shot 2017-08-23 at 02 52 51" src="https://user-images.githubusercontent.com/6170607/29594016-5a1c8b52-87ae-11e7-91c1-b6eab159d506.png">

---

And here the user view for that state:

<img width="438" alt="screen shot 2017-08-23 at 03 13 59" src="https://user-images.githubusercontent.com/6170607/29594440-2742877e-87b1-11e7-9c89-a890aef0206b.png">

---

And this is how it looks when the selected group doesn't contain any events:

<img width="456" alt="screen shot 2017-08-23 at 02 57 56" src="https://user-images.githubusercontent.com/6170607/29594105-f8426ba8-87ae-11e7-901e-38e484c3a343.png">