### PR TITLE
Tell Circle CI to build on every commit

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,12 @@ machine:
     version: 8.2
 
 deployment:
+  artifacts:
+    branch: /.*/
+    owner: zeit
+    commands:
+      - npm run dist -- -p 'never'
+      - cp dist/*.zip $CIRCLE_ARTIFACTS
   release:
     tag: /.*/
     commands:


### PR DESCRIPTION
This allows us to download signed builds right from the Circle CI dashboard (just like with Hyper).