### PR TITLE
Ensure that always enough events are cached

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -508,7 +508,7 @@ class Feed extends React.Component {
     for (const group of groups) {
       const { length } = this.filterEvents(scopedEvents, relatedTeam, group)
 
-      if (length > 30) {
+      if (length > 10) {
         continue
       }
 

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -508,6 +508,8 @@ class Feed extends React.Component {
     for (const group of groups) {
       const { length } = this.filterEvents(scopedEvents, relatedTeam, group)
 
+      // Ensure that always at least 10 events
+      // are cached for each event group
       if (length > 10) {
         continue
       }

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -510,7 +510,7 @@ class Feed extends React.Component {
 
       // Ensure that always at least 10 events
       // are cached for each event group
-      if (length > 10) {
+      if (length >= 10) {
         continue
       }
 


### PR DESCRIPTION
We only need to ensure that about 10 events are renderable for each group (Me, Team, System), because the view only has space for about half of that.