### PR TITLE
Prevent `team` messages from throwing an error

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -466,8 +466,11 @@ class Feed extends React.Component {
   }
 
   setScopeWithSlug(slug) {
-    const { id } = this.detectScope('slug', slug)
-    this.setScope(id)
+    const detected = this.detectScope('slug', slug)
+
+    if (detected) {
+      this.setScope(detected.id)
+    }
   }
 
   detectScope(property, value) {


### PR DESCRIPTION
Previously, an error was thrown if a team didn't exist for the event message.