### PR TITLE
Correctly handle the old config files

### DIFF
--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -113,7 +113,10 @@ exports.saveConfig = async (data, type) => {
   } catch (err) {}
 
   if (type === 'config') {
-    data = { sh: data }
+    // Only create a sub prop for the new config
+    if (isNew) {
+      data = { sh: data }
+    }
 
     // Merge new data with the existing
     currentContent = deepExtend(currentContent, data)


### PR DESCRIPTION
We should only use the `sh` provider sub property in `.now/config.json`, not in `.now.json`. This ensures that the old config can be read properly!