### PR TITLE
Introduced a better name for the login token

### DIFF
--- a/renderer/components/tutorial/login.js
+++ b/renderer/components/tutorial/login.js
@@ -66,7 +66,7 @@ class LoginForm extends PureComponent {
 
     const body = JSON.stringify({
       email,
-      tokenName: 'Now on ' + host
+      tokenName: 'Now Desktop on ' + host
     })
 
     const apiURL = `${url}/now/registration`

--- a/renderer/components/tutorial/login.js
+++ b/renderer/components/tutorial/login.js
@@ -66,7 +66,7 @@ class LoginForm extends PureComponent {
 
     const body = JSON.stringify({
       email,
-      tokenName: 'Now Desktop on ' + host
+      tokenName: `Now Desktop on ${host}`
     })
 
     const apiURL = `${url}/now/registration`


### PR DESCRIPTION
This will make "Now Desktop on ..." show up in your dashboard instead of "Now on ..." (token list).

Same for the CLI: https://github.com/zeit/now-cli/pull/837

**BEFORE**

<img width="503" alt="screen shot 2017-09-12 at 12 25 14" src="https://user-images.githubusercontent.com/6170607/30321191-7b1ea3c8-97b5-11e7-9ee8-b43376bfc360.png">

**AFTER**

<img width="476" alt="screen shot 2017-09-12 at 12 21 21" src="https://user-images.githubusercontent.com/6170607/30321196-804a905a-97b5-11e7-8947-8125cc792932.png">
