### PR TITLE
Some tweaks to make it more macOS compliant

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -82,10 +82,10 @@ exports.innerMenu = async function(app, tray, windows) {
       type: 'separator'
     },
     {
-      label: 'Options',
+      label: 'Preferences',
       submenu: [
         {
-          label: 'Open at Login',
+          label: 'Launch at Login',
           type: 'checkbox',
           checked: openAtLogin,
           click() {
@@ -100,9 +100,8 @@ exports.innerMenu = async function(app, tray, windows) {
       type: 'separator'
     },
     {
-      label: process.platform === 'darwin' ? `Quit ${app.getName()}` : 'Quit',
-      click: app.quit,
-      role: 'quit'
+      role: 'quit',
+      accelerator: 'Cmd+Q'
     }
   ])
 }
@@ -119,8 +118,8 @@ exports.outerMenu = (app, windows) => {
       type: 'separator'
     },
     {
-      label: process.platform === 'darwin' ? `Quit ${app.getName()}` : 'Quit',
-      role: 'quit'
+      role: 'quit',
+      accelerator: 'Cmd+Q'
     }
   ])
 }


### PR DESCRIPTION
On macOS, we use `Preferences`, not `Options`. On Linux and Windows, I've seen both used, so I guess we can just prefer `Preferences`.

`Launch at Login` is a more commonly used term in macOS apps.

I also removed `label` from the Quit menus as it's handled for us when `role: 'quit'` is defined.

And I added a Cmd+Q for convenience, which is also often defined in menubar apps.