### PR TITLE
Don't notify user when copying event data

### DIFF
--- a/renderer/components/feed/event.js
+++ b/renderer/components/feed/event.js
@@ -62,18 +62,12 @@ class EventMessage extends React.PureComponent {
     })
   }
 
-  copyToClipboard(text, type) {
+  copyToClipboard(text) {
     if (!this.remote) {
       return
     }
 
-    const notify = this.remote.require('./notify')
     this.remote.clipboard.writeText(text)
-
-    notify({
-      title: 'Copied to Clipboard',
-      body: `Your clipboard now contains the selected ${type}.`
-    })
   }
 
   getID() {


### PR DESCRIPTION
When copying the URL or the ID of a deployment in the event stream, we should not trigger a notification (it's just disturbing).

Some apps are doing this, but only when getting data from the internet - we don't do that.