### PR TITLE
Added ability to switch the update channel

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -101,7 +101,13 @@ exports.innerMenu = async function(app, tray, windows) {
           checked: isCanary,
           click() {
             const canary = isCanary ? null : true
-            saveConfig({ desktop: { canary } }, 'config')
+
+            saveConfig(
+              {
+                desktop: { canary }
+              },
+              'config'
+            )
           }
         }
       ]

--- a/main/menu.js
+++ b/main/menu.js
@@ -9,7 +9,7 @@ const { getConfig, saveConfig } = require('./utils/config')
 exports.innerMenu = async function(app, tray, windows) {
   const config = await getConfig()
   const { openAtLogin } = app.getLoginItemSettings()
-  const isCanary = config.desktop && config.desktop.canary
+  const isCanary = config.canary
 
   return Menu.buildFromTemplate([
     {
@@ -100,11 +100,9 @@ exports.innerMenu = async function(app, tray, windows) {
           type: 'checkbox',
           checked: isCanary,
           click() {
-            const canary = isCanary ? null : true
-
             saveConfig(
               {
-                desktop: { canary }
+                canary: isCanary ? null : true
               },
               'config'
             )

--- a/main/menu.js
+++ b/main/menu.js
@@ -4,11 +4,12 @@ const { Menu, shell } = require('electron')
 // Utilities
 const logout = require('./utils/logout')
 const toggleWindow = require('./utils/frames/toggle')
-const { getConfig } = require('./utils/config')
+const { getConfig, saveConfig } = require('./utils/config')
 
 exports.innerMenu = async function(app, tray, windows) {
   const config = await getConfig()
   const { openAtLogin } = app.getLoginItemSettings()
+  const isCanary = config.desktop && config.desktop.canary
 
   return Menu.buildFromTemplate([
     {
@@ -92,6 +93,15 @@ exports.innerMenu = async function(app, tray, windows) {
             app.setLoginItemSettings({
               openAtLogin: !openAtLogin
             })
+          }
+        },
+        {
+          label: 'Canary Updates',
+          type: 'checkbox',
+          checked: isCanary,
+          click() {
+            const canary = isCanary ? null : true
+            saveConfig({ desktop: { canary } }, 'config')
           }
         }
       ]

--- a/main/updates.js
+++ b/main/updates.js
@@ -169,8 +169,9 @@ const startAppUpdates = async mainWindow => {
   })
 
   const { platform } = process
-  const isCanary = config.desktop && config.desktop.canary
-  const channel = isCanary ? 'releases-canary' : 'releases'
+  const { canary } = config
+
+  const channel = canary ? 'releases-canary' : 'releases'
   const feedURL = `https://now-desktop-${channel}.zeit.sh/update/${platform}`
 
   try {

--- a/main/updates.js
+++ b/main/updates.js
@@ -17,7 +17,6 @@ const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
 const { platform } = process
-const feedURL = `https://now-desktop-releases.zeit.sh/update/${platform}`
 
 const localBinaryVersion = async () => {
   // We need to modify the `cwd` to prevent the app itself (Now.exe) to be
@@ -170,6 +169,10 @@ const startAppUpdates = async mainWindow => {
     // Then check again for update after 15 minutes
     setTimeout(checkForUpdates, ms('15m'))
   })
+
+  const isCanary = config.desktop && config.desktop.canary
+  const channel = isCanary ? 'releases-canary' : 'releases'
+  const feedURL = `https://now-desktop-${channel}.zeit.sh/update/${platform}`
 
   try {
     autoUpdater.setFeedURL(feedURL + '/' + app.getVersion())

--- a/main/updates.js
+++ b/main/updates.js
@@ -16,8 +16,6 @@ const notify = require('./notify')
 const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
-const { platform } = process
-
 const localBinaryVersion = async () => {
   // We need to modify the `cwd` to prevent the app itself (Now.exe) to be
   // executed on Windows. On other platforms this shouldn't produce side effects.
@@ -170,6 +168,7 @@ const startAppUpdates = async mainWindow => {
     setTimeout(checkForUpdates, ms('15m'))
   })
 
+  const { platform } = process
   const isCanary = config.desktop && config.desktop.canary
   const channel = isCanary ? 'releases-canary' : 'releases'
   const feedURL = `https://now-desktop-${channel}.zeit.sh/update/${platform}`

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -146,7 +146,7 @@ const canaryCheck = async () => {
     config = {}
   }
 
-  return config.desktop && config.desktop.canary
+  return config.canary
 }
 
 exports.installedWithNPM = async () => {

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -21,6 +21,7 @@ const pipe = require('promisepipe')
 // Utilities
 const { runAsRoot } = require('../dialogs')
 const userAgent = require('./user-agent')
+const { getConfig } = require('./config')
 
 // Ensures that the `now.exe` directory is on the user's `PATH`
 const ensurePath = async () => {
@@ -136,6 +137,18 @@ const platformName = () => {
   return name
 }
 
+const canaryCheck = async () => {
+  let config
+
+  try {
+    config = await getConfig(true)
+  } catch (err) {
+    config = {}
+  }
+
+  return config.desktop && config.desktop.canary
+}
+
 exports.installedWithNPM = async () => {
   let packages
 
@@ -241,13 +254,15 @@ exports.getURL = async () => {
     throw new Error('Binary response not okay')
   }
 
-  const { stable } = await response.json()
+  const isCanary = await canaryCheck()
+  const releases = await response.json()
+  const release = isCanary ? releases.canary : releases.stable
 
-  if (!stable || !stable.assets || stable.assets.length < 1) {
+  if (!release || !release.assets || release.assets.length < 1) {
     throw new Error('Not able to get URL of latest binary')
   }
 
-  const forPlatform = stable.assets.find(
+  const forPlatform = release.assets.find(
     asset => asset.platform === platformName()
   )
 
@@ -263,7 +278,7 @@ exports.getURL = async () => {
 
   return {
     url: downloadURL,
-    version: stable.tag,
+    version: release.tag,
     binaryName: forPlatform.name
   }
 }

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -25,7 +25,7 @@ for (const file in paths) {
 
 let configWatcher = null
 
-exports.hasNewConfig = async () => {
+const hasNewConfig = async () => {
   if (!await pathExists(paths.auth)) {
     return false
   }
@@ -37,12 +37,10 @@ exports.hasNewConfig = async () => {
   return true
 }
 
-exports.configPaths = paths
-
 exports.getConfig = async noCheck => {
   let content = {}
 
-  if (await exports.hasNewConfig()) {
+  if (await hasNewConfig()) {
     const { credentials } = await fs.readJSON(paths.auth)
     const { token } = credentials.find(item => item.provider === 'sh')
     const { sh } = await fs.readJSON(paths.config)
@@ -72,7 +70,7 @@ exports.removeConfig = async () => {
     configWatcher = null
   }
 
-  if (await exports.hasNewConfig()) {
+  if (await hasNewConfig()) {
     const configContent = await fs.readJSON(paths.config)
     delete configContent.sh
 
@@ -99,7 +97,7 @@ exports.removeConfig = async () => {
 }
 
 exports.saveConfig = async (data, type) => {
-  let isNew = await exports.hasNewConfig()
+  let isNew = await hasNewConfig()
 
   // Ensure that we're writing to the new config
   // destination, if no config exists yet
@@ -196,7 +194,7 @@ const configChanged = async logout => {
 exports.watchConfig = async () => {
   let toWatch = [paths.old]
 
-  if (await exports.hasNewConfig()) {
+  if (await hasNewConfig()) {
     toWatch = [paths.auth, paths.config]
   } else if (!await pathExists(paths.old)) {
     return

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -25,7 +25,7 @@ for (const file in paths) {
 
 let configWatcher = null
 
-const hasNewConfig = async () => {
+exports.hasNewConfig = async () => {
   if (!await pathExists(paths.auth)) {
     return false
   }
@@ -37,10 +37,12 @@ const hasNewConfig = async () => {
   return true
 }
 
+exports.configPaths = paths
+
 exports.getConfig = async noCheck => {
   let content = {}
 
-  if (await hasNewConfig()) {
+  if (await exports.hasNewConfig()) {
     const { credentials } = await fs.readJSON(paths.auth)
     const { token } = credentials.find(item => item.provider === 'sh')
     const { sh } = await fs.readJSON(paths.config)
@@ -70,7 +72,7 @@ exports.removeConfig = async () => {
     configWatcher = null
   }
 
-  if (await hasNewConfig()) {
+  if (await exports.hasNewConfig()) {
     const configContent = await fs.readJSON(paths.config)
     delete configContent.sh
 
@@ -97,7 +99,7 @@ exports.removeConfig = async () => {
 }
 
 exports.saveConfig = async (data, type) => {
-  let isNew = await hasNewConfig()
+  let isNew = await exports.hasNewConfig()
 
   // Ensure that we're writing to the new config
   // destination, if no config exists yet
@@ -194,7 +196,7 @@ const configChanged = async logout => {
 exports.watchConfig = async () => {
   let toWatch = [paths.old]
 
-  if (await hasNewConfig()) {
+  if (await exports.hasNewConfig()) {
     toWatch = [paths.auth, paths.config]
   } else if (!await pathExists(paths.old)) {
     return


### PR DESCRIPTION
This allows users to switch to a different update channel named "canary". It will provide beta updates for both Now Desktop and Now CLI.

This closes #375.

The new option can be accessed like this:

<img width="359" alt="screen shot 2017-10-01 at 00 00 13" src="https://user-images.githubusercontent.com/6170607/31049811-92a7b4c8-a63b-11e7-9d7b-603f687f5fc3.png">
