### PR TITLE
Better position for `updateChannel` config property

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -9,7 +9,8 @@ const { getConfig, saveConfig } = require('./utils/config')
 exports.innerMenu = async function(app, tray, windows) {
   const config = await getConfig()
   const { openAtLogin } = app.getLoginItemSettings()
-  const isCanary = config.canary
+  const { updateChannel } = config
+  const isCanary = updateChannel && updateChannel === 'canary'
 
   return Menu.buildFromTemplate([
     {
@@ -102,7 +103,7 @@ exports.innerMenu = async function(app, tray, windows) {
           click() {
             saveConfig(
               {
-                canary: isCanary ? null : true
+                updateChannel: isCanary ? 'stable' : 'canary'
               },
               'config'
             )

--- a/main/updates.js
+++ b/main/updates.js
@@ -120,9 +120,10 @@ const setUpdateURL = async () => {
   } catch (err) {}
 
   const { platform } = process
-  const { canary } = config
+  const { updateChannel } = config
 
-  const channel = canary ? 'releases-canary' : 'releases'
+  const isCanary = updateChannel && updateChannel === 'canary'
+  const channel = isCanary ? 'releases-canary' : 'releases'
   const feedURL = `https://now-desktop-${channel}.zeit.sh/update/${platform}`
 
   try {


### PR DESCRIPTION
The new way of enabling canary updates inside `.now/config.json`:

```json
{
  "updateChannel": "canary"
}
```

This also ensures that the property is set to "stable" by default.