### PR TITLE
Make binary updates respect the update channel

### DIFF
--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -256,7 +256,6 @@ exports.getURL = async () => {
   }
 
   const isCanary = await canaryCheck()
-  console.log(isCanary)
   const releases = await response.json()
   const release = isCanary ? releases.canary : releases.stable
 

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -146,7 +146,8 @@ const canaryCheck = async () => {
     config = {}
   }
 
-  return config.canary
+  const { updateChannel } = config
+  return updateChannel && updateChannel === 'canary'
 }
 
 exports.installedWithNPM = async () => {
@@ -255,6 +256,7 @@ exports.getURL = async () => {
   }
 
   const isCanary = await canaryCheck()
+  console.log(isCanary)
   const releases = await response.json()
   const release = isCanary ? releases.canary : releases.stable
 


### PR DESCRIPTION
Because we introduced a new config property for setting the update channel, we need to adjust the mechanism for downloading binary updates to respect it.