### PR TITLE
Downgrade CLI to latest stable when disabling canary setting

### DIFF
--- a/main/updates.js
+++ b/main/updates.js
@@ -17,12 +17,15 @@ const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
 const checkIfCanary = async () => {
-  let updateChannel
+  let config
 
   try {
-    ;({ updateChannel } = await getConfig(true))
-  } catch (err) {}
+    config = await getConfig(true)
+  } catch (err) {
+    throw new Error(`The config file couldn't be read`)
+  }
 
+  const { updateChannel } = config
   return updateChannel && updateChannel === 'canary'
 }
 
@@ -155,7 +158,12 @@ const checkForUpdates = async () => {
   }
 
   // Ensure we're pulling from the correct channel
-  await setUpdateURL()
+  try {
+    await setUpdateURL()
+  } catch (err) {
+    // Retry later if setting the update URL failed
+    return
+  }
 
   // Then ask the server for updates
   autoUpdater.checkForUpdates()

--- a/main/updates.js
+++ b/main/updates.js
@@ -42,7 +42,7 @@ const localBinaryVersion = async () => {
   // Later in the code, we force an update if getting
   // the latest local version results in `false` or fails
   // so we can use this opportunity in the statement below
-  // and and trigger that.
+  // and trigger that.
 
   // The result will be a downgrade to the latest stable
   // version when the setting "Canary Updates" gets disabled.

--- a/main/updates.js
+++ b/main/updates.js
@@ -17,15 +17,7 @@ const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
 const checkIfCanary = async () => {
-  let config
-
-  try {
-    config = await getConfig(true)
-  } catch (err) {
-    throw new Error(`The config file couldn't be read`)
-  }
-
-  const { updateChannel } = config
+  const { updateChannel } = await getConfig(true)
   return updateChannel && updateChannel === 'canary'
 }
 

--- a/main/updates.js
+++ b/main/updates.js
@@ -45,7 +45,7 @@ const localBinaryVersion = async () => {
   // and trigger that.
 
   // The result will be a downgrade to the latest stable
-  // version when the setting "Canary Updates" gets disabled.
+  // release when the setting "Canary Updates" gets disabled.
 
   if (output.includes('canary') && !await checkIfCanary()) {
     console.log('Downgrading binary from canary to stable channel...')

--- a/main/updates.js
+++ b/main/updates.js
@@ -21,6 +21,11 @@ const isCanary = async () => {
   return updateChannel && updateChannel === 'canary'
 }
 
+// If the local version was found, it will be
+// return as a `String`. If it was found but is meant
+// to be leading to a downgrade, it will
+// return `null`. In all other cases, an error
+// will be thrown leading to a retry.
 const localBinaryVersion = async () => {
   // We need to modify the `cwd` to prevent the app itself (Now.exe) to be
   // executed on Windows. On other platforms this shouldn't produce side effects.
@@ -44,7 +49,7 @@ const localBinaryVersion = async () => {
 
   if (output.includes('canary') && !await isCanary()) {
     console.log('Downgrading binary from canary to stable channel...')
-    return false
+    return null
   }
 
   if (semVer.valid(output)) {

--- a/main/updates.js
+++ b/main/updates.js
@@ -16,7 +16,7 @@ const notify = require('./notify')
 const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
-const checkIfCanary = async () => {
+const isCanary = async () => {
   const { updateChannel } = await getConfig(true)
   return updateChannel && updateChannel === 'canary'
 }
@@ -42,7 +42,7 @@ const localBinaryVersion = async () => {
   // The result will be a downgrade to the latest stable
   // release when the setting "Canary Updates" gets disabled.
 
-  if (output.includes('canary') && !await checkIfCanary()) {
+  if (output.includes('canary') && !await isCanary()) {
     console.log('Downgrading binary from canary to stable channel...')
     return false
   }
@@ -133,8 +133,7 @@ const startBinaryUpdates = () => {
 const setUpdateURL = async () => {
   const { platform } = process
 
-  const isCanary = await checkIfCanary()
-  const channel = isCanary ? 'releases-canary' : 'releases'
+  const channel = (await isCanary()) ? 'releases-canary' : 'releases'
   const feedURL = `https://now-desktop-${channel}.zeit.sh/update/${platform}`
 
   try {


### PR DESCRIPTION
Before this PR, you were stuck on the canary release if one somehow found its way on your device although you had "Canary Updates" disabled.

This might also have happened on purpose because you had it enabled before, got a canary update delivered and now you just don't want them anymore and decided to disable the setting.

In both cases, you want to be downgraded to the **latest stable Now CLI** release.