### PR TITLE
Fixed a regression introduced in #396

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -295,7 +295,7 @@ class Feed extends React.Component {
       const scopedEvents = events[scope]
       let groupedEvents
 
-      if (scopedEvents && scopedEvents[group]) {
+      if (scopedEvents) {
         groupedEvents = scopedEvents[group]
       } else {
         events[scope] = {}


### PR DESCRIPTION
This makes event loading work again. It was broken because the property modified in this PR is allowed to have a falsy value.