### PR TITLE
Added preference for binary updates and fixed team order

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -9,8 +9,16 @@ const { getConfig, saveConfig } = require('./utils/config')
 exports.innerMenu = async function(app, tray, windows) {
   const config = await getConfig()
   const { openAtLogin } = app.getLoginItemSettings()
-  const { updateChannel } = config
+  const { updateChannel, desktop } = config
   const isCanary = updateChannel && updateChannel === 'canary'
+
+  let updateCLI = true
+
+  // This check needs to be explicit (updates should be
+  // enabled by default if the config property is not set)
+  if (desktop && desktop.updateCLI === false) {
+    updateCLI = false
+  }
 
   return Menu.buildFromTemplate([
     {
@@ -97,13 +105,31 @@ exports.innerMenu = async function(app, tray, windows) {
           }
         },
         {
-          label: 'Canary Updates',
+          type: 'separator'
+        },
+        {
+          label: 'Canary Releases',
           type: 'checkbox',
           checked: isCanary,
           click() {
             saveConfig(
               {
                 updateChannel: isCanary ? 'stable' : 'canary'
+              },
+              'config'
+            )
+          }
+        },
+        {
+          label: 'Auto-Update Now CLI',
+          type: 'checkbox',
+          checked: updateCLI,
+          click() {
+            saveConfig(
+              {
+                desktop: {
+                  updateCLI: !updateCLI
+                }
               },
               'config'
             )

--- a/main/updates.js
+++ b/main/updates.js
@@ -123,6 +123,21 @@ const updateBinary = async () => {
 const startBinaryUpdates = () => {
   const binaryUpdateTimer = time =>
     setTimeout(async () => {
+      let config = {}
+
+      try {
+        config = await getConfig(true)
+      } catch (err) {}
+
+      // This needs to be explicit
+      if (config.desktop && config.desktop.updateCLI === false) {
+        console.log(`Skipping binary updates because they're disabled...`)
+
+        // Try again in 5 minutes
+        binaryUpdateTimer(ms('5m'))
+        return
+      }
+
       try {
         await updateBinary()
         binaryUpdateTimer(ms('10m'))

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -43,11 +43,15 @@ exports.getConfig = async noCheck => {
   if (await hasNewConfig()) {
     const { credentials } = await fs.readJSON(paths.auth)
     const { token } = credentials.find(item => item.provider === 'sh')
-    const { sh, updateChannel } = await fs.readJSON(paths.config)
+    const { sh, updateChannel, desktop } = await fs.readJSON(paths.config)
     const isCanary = updateChannel && updateChannel === 'canary'
 
     if (sh.canary || isCanary) {
       content.updateChannel = 'canary'
+    }
+
+    if (desktop) {
+      content.desktop = desktop
     }
 
     Object.assign(content, sh, { token })
@@ -120,12 +124,20 @@ exports.saveConfig = async (data, type) => {
   if (type === 'config') {
     // Only create a sub prop for the new config
     if (isNew) {
-      const { updateChannel } = data
+      // These are top-level properties
+      const { updateChannel, desktop } = data
+
+      // Inject the content
       data = { sh: data }
 
       if (updateChannel) {
         data.updateChannel = updateChannel
         delete data.sh.updateChannel
+      }
+
+      if (desktop) {
+        data.desktop = desktop
+        delete data.sh.desktop
       }
     }
 
@@ -134,6 +146,8 @@ exports.saveConfig = async (data, type) => {
         'This is your Now config file. See `now config help`. More: https://git.io/v5ECz'
       currentContent.updateChannel = 'stable'
     }
+
+    console.log(data)
 
     // Merge new data with the existing
     currentContent = deepExtend(currentContent, data)

--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -255,32 +255,6 @@ class Switcher extends React.Component {
     this.changeScope(config.currentTeam, true)
   }
 
-  handleSavedOrder(newData, order) {
-    if (!order) {
-      return
-    }
-
-    const ordered = JSON.parse(JSON.stringify(order))
-
-    for (const position of ordered) {
-      const index = ordered.indexOf(position)
-
-      ordered[index] = newData.find(item => {
-        const name = item.slug || item.name
-        return name === position
-      })
-    }
-
-    if (!compare(newData, ordered)) {
-      return
-    }
-
-    // Remove property `teamOrder` from config
-    this.saveConfig({
-      desktop: { teamOrder: null }
-    })
-  }
-
   async saveConfig(newConfig) {
     const { saveConfig } = this.configUtils
 
@@ -356,9 +330,6 @@ class Switcher extends React.Component {
       })
     }
 
-    // See if the saved order is even necessary
-    this.handleSavedOrder(list, order)
-
     // Apply the new data at the end, but keep order
     return this.merge(newList, list)
   }
@@ -384,8 +355,6 @@ class Switcher extends React.Component {
     const order = await this.getTeamOrder()
 
     if (compare(ordered, currentData)) {
-      // See if the saved order is even necessary
-      this.handleSavedOrder(newData, order)
       return false
     }
 


### PR DESCRIPTION
With this PR, Now Desktop gets a preference for toggling the binary updates as per #401:

<img width="469" alt="screen shot 2017-11-08 at 13 10 47" src="https://user-images.githubusercontent.com/6170607/32548702-e499c104-c486-11e7-993c-8c6921c3aa5d.png">

As a nice side effect, it also fixes #389 (and closes #401).