### PR TITLE
Support for dropping multiple files added

### DIFF
--- a/main/dialogs.js
+++ b/main/dialogs.js
@@ -6,16 +6,6 @@ const { resolve: resolvePath } = require('app-root-path')
 // Utilities
 const deploy = require('./utils/deploy')
 
-const showDialog = details => {
-  const filePath = dialog.showOpenDialog(details)
-
-  if (filePath) {
-    return filePath[0]
-  }
-
-  return false
-}
-
 exports.runAsRoot = (command, why) => {
   const answer = dialog.showMessageBox({
     type: 'question',
@@ -60,19 +50,21 @@ exports.error = (detail, trace, win) => {
 }
 
 exports.deploy = async () => {
-  const info = {
+  const details = {
     title: 'Select a file or directory to deploy',
-    properties: ['openDirectory', 'openFile'],
+    properties: ['openDirectory', 'openFile', 'multiSelections'],
     buttonLabel: 'Deploy'
   }
 
-  const path = showDialog(info)
+  const paths = dialog.showOpenDialog(details)
 
-  if (path) {
-    try {
-      await deploy(path)
-    } catch (err) {
-      exports.error('Not able to deploy', err)
-    }
+  if (!paths) {
+    return
+  }
+
+  try {
+    await deploy(paths)
+  } catch (err) {
+    exports.error('Not able to deploy', err)
   }
 }

--- a/main/index.js
+++ b/main/index.js
@@ -97,7 +97,7 @@ const contextMenu = async windows => {
   return innerMenu(app, tray, windows)
 }
 
-const fileDropped = async (event, files) => {
+const filesDropped = async (event, files) => {
   event.preventDefault()
 
   if (process.env.CONNECTION === 'offline') {
@@ -109,14 +109,7 @@ const fileDropped = async (event, files) => {
     return
   }
 
-  if (files.length > 1) {
-    showError(
-      "It's not yet possible to share multiple files/directories at once."
-    )
-    return
-  }
-
-  await deploy(files[0])
+  await deploy(files)
 }
 
 const moveApp = async config => {
@@ -262,7 +255,7 @@ app.on('ready', async () => {
   }
 
   // Define major event listeners for tray
-  tray.on('drop-files', fileDropped)
+  tray.on('drop-files', filesDropped)
   tray.on('click', toggleActivity)
   tray.on('double-click', toggleActivity)
 

--- a/main/utils/deploy/index.js
+++ b/main/utils/deploy/index.js
@@ -495,11 +495,12 @@ const mergeFiles = async paths => {
 
 module.exports = async paths => {
   const loadingPlan = getPlan()
+  const multiple = paths.length > 1
 
   let path = paths
   let deploymentType
 
-  if (paths.length > 1) {
+  if (multiple) {
     path = await mergeFiles(paths)
   }
 
@@ -531,18 +532,20 @@ module.exports = async paths => {
     currentTeam: config.currentTeam || false
   })
 
+  const metaData = await readMetaData(path, {
+    deploymentType
+  })
+
+  if (multiple) {
+    metaData.name = 'files'
+  }
+
   await retry(
     async () => {
       let notified = false
 
       do {
-        await now.create(
-          path,
-          await readMetaData(path, {
-            deploymentType
-          })
-        )
-
+        await now.create(path, metaData)
         const { url } = now
 
         if (url && !notified) {

--- a/renderer/components/feed/dropzone.js
+++ b/renderer/components/feed/dropzone.js
@@ -40,10 +40,11 @@ class DropZone extends React.PureComponent {
       return
     }
 
-    const item = event.dataTransfer.files[0].path
+    const { files } = event.dataTransfer
+    const list = [...files].map(file => file.path)
 
-    // Shoot it into the cloud
-    this.deploy(item)
+    // Shoot them into the cloud
+    this.deploy(list)
 
     // And prevent the window from loading the file inside it
     event.preventDefault()


### PR DESCRIPTION
After this PR, Now Desktop will let you drop multiple files onto the tray icon or the window. Then it will bundle them all to one single deployment (and still consider the type).

Technically, you could even select a few files from a Docker project (instead of the directory) and it will still consider it a Docker deployment. 🐳 

This closes #399.