### PR TITLE
Make installation of Now CLI work on slow networks

### DIFF
--- a/main/updates.js
+++ b/main/updates.js
@@ -150,6 +150,8 @@ const startBinaryUpdates = () => {
       try {
         if (update) {
           await updateBinary()
+        } else if (config.desktop && config.desktop.updateCLI === true) {
+          await binaryUtils.install()
         } else {
           await binaryUtils.installBundleTemp()
         }


### PR DESCRIPTION
 Fixes #411 cc @leo

Summary of changes:
1. Initialized event listener before download starts.
2. Change update to install directly if the updateCLI is set to true.

Testing done:
Tested these changes on a slow and fast network for the following flows.
1. User checks the cli-checkbox
2. User does not check the cli-checkbox

Apologies for introducing this bug. Let me know if these changes help.

Also let me know whether a new branch is the right place to add these changes or should I add these to the previous branch i.e melvin0008:melvin0008_tweak_cli_flow

