### PR TITLE
Adapt to changing the token in the config file

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -118,7 +118,7 @@ app.on('ready', async () => {
   let config
 
   try {
-    config = await getConfig(true)
+    config = await getConfig()
   } catch (err) {
     config = {}
   }

--- a/main/updates.js
+++ b/main/updates.js
@@ -17,7 +17,7 @@ const binaryUtils = require('./utils/binary')
 const { getConfig, saveConfig } = require('./utils/config')
 
 const isCanary = async () => {
-  const { updateChannel } = await getConfig(true)
+  const { updateChannel } = await getConfig()
   return updateChannel && updateChannel === 'canary'
 }
 
@@ -126,7 +126,7 @@ const startBinaryUpdates = () => {
       let config = {}
 
       try {
-        config = await getConfig(true)
+        config = await getConfig()
       } catch (err) {}
 
       // This needs to be explicit
@@ -210,7 +210,7 @@ const startAppUpdates = async mainWindow => {
   let config
 
   try {
-    config = await getConfig(true)
+    config = await getConfig()
   } catch (err) {
     config = {}
   }

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -143,7 +143,7 @@ const canaryCheck = async () => {
   let config
 
   try {
-    config = await getConfig(true)
+    config = await getConfig()
   } catch (err) {
     config = {}
   }

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -74,10 +74,11 @@ exports.getConfig = async () => {
   }
 
   if (!content.token) {
+    oldToken = null
     throw new Error('No user token defined')
   }
 
-  if (oldToken && content.token && oldToken !== content.token) {
+  if (oldToken && oldToken !== content.token) {
     tokenChanged = true
   }
 

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -364,17 +364,20 @@ class Feed extends React.Component {
     // Update the `currentUser` state to reflect
     // switching the account using `now login`
     this.ipcRenderer.on('config-changed', (event, config) => {
-      if (compare(this.state.currentUser, config.user)) {
+      const { user } = config
+
+      if (compare(this.state.currentUser, user)) {
         return
       }
 
-      // Clear up the events to load new ones
-      const events = this.state.events
-
-      events[this.state.scope] = []
-      events[config.user.uid] = []
-
-      this.setState({ currentUser: config.user, events })
+      this.setState({
+        scope: user.uid,
+        currentUser: user,
+        events: {},
+        teams: [],
+        eventFilter: null,
+        typeFilter: 'team'
+      })
     })
   }
 


### PR DESCRIPTION
It wasn't easy, but now we support manual changes to the `token` or `user` property in any of our global configuration files. Now Desktop will automatically adapt, download the missing information or log you out if the token isn't valid. 🌷 

This closes #405.