### PR TITLE
Prevent disk from filling up

### DIFF
--- a/main/updates.js
+++ b/main/updates.js
@@ -138,28 +138,12 @@ const startBinaryUpdates = () => {
         return
       }
 
-      let failureRetryTime = '1m'
-      let update = true
-
-      // If file doesn't exist make a fresh install
-      if (!await binaryUtils.isInstalled()) {
-        failureRetryTime = '30s'
-        update = false
-      }
-
       try {
-        if (update) {
-          await updateBinary()
-        } else if (config.desktop && config.desktop.updateCLI === true) {
-          await binaryUtils.install()
-        } else {
-          await binaryUtils.installBundleTemp()
-        }
-
-        binaryUpdateTimer(ms('1m'))
+        await updateBinary()
+        binaryUpdateTimer(ms('10m'))
       } catch (err) {
         console.log(err)
-        binaryUpdateTimer(ms(failureRetryTime))
+        binaryUpdateTimer(ms('1m'))
       }
     }, time)
 


### PR DESCRIPTION
With #407, we introduced a huge change to the update mechanism which basically leads to the binary file being installed even if an installation wasn't asked for.

In cases where further permissions are required, the creation of the temporary directory failed or the installation failed in a different place, this led to the disk getting filled up endlessly.

This PR fixes the update mechanism by bringing it back to the bullet-proof way.

I didn't intentionally wanted to have – what we currently have – in place, but I must have overlooked it while reviewing #407. So this PR simply fixes that mistake of mine!

---

**Just to be clear:** This leaves the automated mechanism we use for installing the CLI when the user opens the app completely untouched. ☺️ 

---

This closes #417.