### PR TITLE
Prevent event stream from getting stuck

### DIFF
--- a/main/utils/data/load.js
+++ b/main/utils/data/load.js
@@ -1,5 +1,6 @@
 // Packages
 const fetch = require('node-fetch')
+const ms = require('ms')
 
 // Utilities
 const { getConfig } = require('../config')
@@ -37,7 +38,11 @@ module.exports = async (path, token) => {
   let error
 
   try {
-    res = await fetch(url, { headers })
+    res = await fetch(url, {
+      headers,
+      timeout: ms('20s')
+    })
+
     if (res.status < 200 || res.status >= 300) {
       if (res.headers.get('Content-Type') === 'application/json') {
         data = await res.json()

--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -155,6 +155,9 @@ class Switcher extends React.Component {
           // It's important that this is being `await`ed
           await this.loadTeams()
         } catch (err) {
+          // Retry first
+          listTimer()
+
           // Check if app is even online
           this.setOnlineState()
 
@@ -164,9 +167,7 @@ class Switcher extends React.Component {
             this.props.onlineStateFeed()
           }
 
-          // Then retry, to ensure that we get the
-          // data once it's working again
-          listTimer()
+          // No need to retry again
           return
         }
 

--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -129,6 +129,10 @@ class Switcher extends React.Component {
       newState.initialized = false
     }
 
+    if (this.state.online === online) {
+      return
+    }
+
     this.setState(newState)
   }
 
@@ -146,31 +150,20 @@ class Switcher extends React.Component {
       const time = isVisible() ? '5s' : '60s'
 
       setTimeout(async () => {
-        if (!this.state.online) {
-          listTimer()
-          return
-        }
-
         try {
           // It's important that this is being `await`ed
           await this.loadTeams()
-        } catch (err) {
-          // Retry first
-          listTimer()
 
           // Check if app is even online
           this.setOnlineState()
 
           // Also do the same for the feed, so that
           // both components reflect the online state
-          if (this.props.onlineStateFeed) {
-            this.props.onlineStateFeed()
-          }
+          this.props.onlineStateFeed()
+        } catch (err) {}
 
-          // No need to retry again
-          return
-        }
-
+        // Once everything is done or has failed,
+        // try it again after some time.
         listTimer()
       }, ms(time))
     }

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -506,7 +506,7 @@ class Feed extends React.Component {
     return new Promise(resolve =>
       this.setState({ teams }, async () => {
         await retry(() => this.updateEvents(firstLoad), {
-          retries: 500
+          retries: 5
         })
 
         resolve()

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -506,7 +506,9 @@ class Feed extends React.Component {
     return new Promise(resolve =>
       this.setState({ teams }, async () => {
         await retry(() => this.updateEvents(firstLoad), {
-          retries: 5
+          retries: 5,
+          factor: 2,
+          maxTimeout: 5000
         })
 
         resolve()

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -621,7 +621,9 @@ class Feed extends React.Component {
       const lastEvent = scopedEvents[scopedEvents.length - 1]
 
       retry(() => this.cacheEvents(scope, lastEvent.created), {
-        retries: 500
+        retries: 5,
+        factor: 2,
+        maxTimeout: 5000
       })
     }
   }

--- a/renderer/utils/data/load.js
+++ b/renderer/utils/data/load.js
@@ -1,5 +1,6 @@
 // Packages
 const electron = require('electron')
+const ms = require('ms')
 
 // Utilities
 const userAgent = require('./user-agent')
@@ -55,7 +56,11 @@ module.exports = async (path, token = null, opts = {}) => {
   let error
 
   try {
-    res = await fetch(url, { ...opts, headers })
+    res = await fetch(url, {
+      ...opts,
+      headers,
+      timeout: ms('20s')
+    })
 
     if (res.status === 403) {
       const remote = electron.remote || false


### PR DESCRIPTION
We had several bad retrying mechanisms in place and many places were missing timeouts. After this, all of those are covered – preventing the event stream from getting stuck.