### PR TITLE
Prevent eventual concurrency of logged in check

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -29,6 +29,10 @@ let tray = null
 // Prevent having to check for login status when opening the window
 let loggedIn = null
 
+// Check status once in the beginning when the app starting up
+// And then every 2 seconds
+// We could to this on click on the tray icon, but we
+// don't want to block that action
 const setLoggedInStatus = async () => {
   let token
 
@@ -37,14 +41,9 @@ const setLoggedInStatus = async () => {
   } catch (err) {}
 
   loggedIn = Boolean(token)
+  setTimeout(setLoggedInStatus, 2000)
 }
-
-// Check status once in the beginning when the app starting up
-// And then every 2 seconds
-// We could to this on click on the tray icon, but we
-// don't want to block that action
 setLoggedInStatus()
-setInterval(setLoggedInStatus, 2000)
 
 // Load the app instance from electron
 const { app } = electron


### PR DESCRIPTION
As the total time spent in `getConfig` approaches and passes 2 seconds it would start running concurrently with itself. Using setTimeout after each check avoids that.