### PR TITLE
Fixed error page for search

### DIFF
--- a/renderer/components/feed/none.js
+++ b/renderer/components/feed/none.js
@@ -12,16 +12,16 @@ const NoEvents = ({ filtered }) => (
   <div>
     {filtered ? (
       <Fragment>
-        <h1 key="heading">No Events Available</h1>,
-        <p key="description">
+        <h1>No Events Available</h1>
+        <p>
           There are no events matching your search pattern. Try a different
-          wording!
+          wording.
         </p>
       </Fragment>
     ) : (
       <Fragment>
-        <h1 key="heading">No Events Found</h1>,
-        <p key="description">
+        <h1>No Events Found</h1>
+        <p>
           You can pick a different category of events using the{' '}
           <FilterIcon background="#F5F5F5" /> filter on the top.
         </p>

--- a/renderer/styles/components/feed/none.js
+++ b/renderer/styles/components/feed/none.js
@@ -14,6 +14,7 @@ export default css`
 
   h1 {
     font-size: 16px;
+    margin: 0 0 20px 0;
   }
 
   p {
@@ -21,6 +22,7 @@ export default css`
     font-size: 12px;
     width: 250px;
     line-height: 20px;
+    margin: 0;
   }
 
   b {


### PR DESCRIPTION
- Removes the comma that appeared on search's error page
- Ensures there's no exclamation mark at the end of the sentence

---

**BEFORE**

![screen shot 2018-02-19 at 11 42 56](https://user-images.githubusercontent.com/6170607/36394657-2b6532d8-156a-11e8-90dd-9f0c0708792a.png)

**AFTER**

![screen shot 2018-02-19 at 11 42 03](https://user-images.githubusercontent.com/6170607/36394664-312418a6-156a-11e8-9e32-8049a6f61511.png)
