### PR TITLE
 Refresh events when window gets opened

### DIFF
--- a/renderer/components/feed/dropzone.js
+++ b/renderer/components/feed/dropzone.js
@@ -52,7 +52,7 @@ class DropZone extends PureComponent {
       >
         <section>
           <span>
-            <h1>Drop to Deploy!</h1>
+            <h1>Drop to Deploy</h1>
             <p>
               Your files will be uploaded to <b>Now</b>.
             </p>

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -421,9 +421,13 @@ class Feed extends Component {
       // resetted if the window was closed for 5 seconds.
       clearTimeout(scrollTimer)
 
-      // Refresh the events when the window gets
-      // shown, so that they're always up-to-date.
-      this.cacheEvents(this.state.scope)
+      const { scope } = this.state
+
+      if (scope) {
+        // Refresh the events when the window gets
+        // shown, so that they're always up-to-date.
+        this.cacheEvents(scope)
+      }
     })
 
     currentWindow.on('hide', () => {

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -177,11 +177,15 @@ class Feed extends Component {
     return groups
   }
 
-  async cacheEvents(scope, until) {
+  async cacheEvents(scope, until, track) {
     const types = this.eventTypes
     const { teams, currentUser, scope: activeScope } = this.state
 
     if (until) {
+      track = true
+    }
+
+    if (track) {
       this.loading.add(scope)
     }
 
@@ -226,7 +230,7 @@ class Feed extends Component {
     try {
       results = await Promise.all(loaders)
     } catch (err) {
-      if (until) {
+      if (track) {
         this.loading.delete(scope)
       }
 
@@ -322,7 +326,9 @@ class Feed extends Component {
         teams
       },
       () => {
-        this.loading.delete(scope)
+        if (track) {
+          this.loading.delete(scope)
+        }
       }
     )
   }
@@ -426,8 +432,8 @@ class Feed extends Component {
 
       // Refresh the events when the window gets
       // shown, so that they're always up-to-date
-      if (scope) {
-        this.cacheEvents(scope)
+      if (scope && !this.loading.has(scope)) {
+        this.cacheEvents(scope, null, true)
       }
     })
 

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -418,14 +418,14 @@ class Feed extends Component {
 
     currentWindow.on('show', () => {
       // Ensure that scrolling position only gets
-      // resetted if the window was closed for 5 seconds.
+      // resetted if the window was closed for 5 seconds
       clearTimeout(scrollTimer)
 
       // Get the currently active scope
       const { scope } = this.state
 
       // Refresh the events when the window gets
-      // shown, so that they're always up-to-date.
+      // shown, so that they're always up-to-date
       if (scope) {
         this.cacheEvents(scope)
       }

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -418,12 +418,16 @@ class Feed extends Component {
 
     currentWindow.on('show', () => {
       // Ensure that scrolling position only gets
-      // resetted if the window was closed for 5 seconds
+      // resetted if the window was closed for 5 seconds.
       clearTimeout(scrollTimer)
+
+      // Refresh the events when the window gets
+      // shown, so that they're always up-to-date.
+      this.cacheEvents(this.state.scope)
     })
 
     currentWindow.on('hide', () => {
-      // Clear scrolling position if window closed for 5 seconds
+      // Clear scrolling position if window closed for 5 seconds.
       scrollTimer = setTimeout(this.clearScroll, ms('5s'))
     })
   }

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -432,7 +432,7 @@ class Feed extends Component {
     })
 
     currentWindow.on('hide', () => {
-      // Clear scrolling position if window closed for 5 seconds.
+      // Clear scrolling position if window closed for 5 seconds
       scrollTimer = setTimeout(this.clearScroll, ms('5s'))
     })
   }

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -421,11 +421,12 @@ class Feed extends Component {
       // resetted if the window was closed for 5 seconds.
       clearTimeout(scrollTimer)
 
+      // Get the currently active scope
       const { scope } = this.state
 
+      // Refresh the events when the window gets
+      // shown, so that they're always up-to-date.
       if (scope) {
-        // Refresh the events when the window gets
-        // shown, so that they're always up-to-date.
         this.cacheEvents(scope)
       }
     })

--- a/renderer/styles/components/feed/dropzone.js
+++ b/renderer/styles/components/feed/dropzone.js
@@ -48,7 +48,6 @@ export default css`
   }
 
   b {
-    font-weight: normal;
-    text-decoration: underline;
+    font-weight: 700;
   }
 `


### PR DESCRIPTION
After this PR, a new request for loading the most recent events for the currently active user or team scope will be sent when the window gets opened.

This should ensure that you don't see out-of-date events when you open the window. ✨ 

Aside from that, it ensures the drop zone looks great:

---

**BEFORE**

![screen shot 2018-02-19 at 13 16 53](https://user-images.githubusercontent.com/6170607/36397322-33d9d920-1577-11e8-87ca-cf92d9edbae0.png)

**AFTER**

![screen shot 2018-02-19 at 13 16 02](https://user-images.githubusercontent.com/6170607/36397329-38da6034-1577-11e8-9597-38ab606ec52f.png)
