### PR TITLE
Ensure binary installation is working on Windows

### DIFF
--- a/main/dialogs.js
+++ b/main/dialogs.js
@@ -32,10 +32,9 @@ exports.runAsRoot = (command, why) => {
       icns: resolvePath('./main/static/icons/mac.icns')
     }
 
-    sudo.exec(command, options, async error => {
+    sudo.exec(command, options, error => {
       if (error) {
-        reject(error)
-        return
+        return reject(error)
       }
 
       resolve()

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -240,8 +240,8 @@ exports.handleExisting = async next => {
   try {
     await fs.ensureDir(parent)
   } catch (err) {
-    const dirPrefix = isWin ? 'md' : 'mkdir -p'
-    const commands = [`${dirPrefix} ${parent}`, copyCommand]
+    const dirCommand = `${isWin ? 'md' : 'mkdir -p'} ${parent}`
+    const commands = [dirCommand, copyCommand]
 
     if (!isWin) {
       commands.splice(1, 0, `chown -R \`whoami\` ${parent}`)

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -241,7 +241,6 @@ exports.handleExisting = async next => {
     await fs.ensureDir(parent)
   } catch (err) {
     const dirPrefix = isWin ? 'md' : 'mkdir -p'
-
     const commands = [`${dirPrefix} ${parent}`, copyCommand]
 
     if (!isWin) {

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -236,7 +236,6 @@ exports.handleExisting = async next => {
   const copyCommand = `${copyPrefix} ${next} ${destFile}`
 
   const why = 'To place Now CLI in the correct location.'
-  console.log(process)
 
   try {
     await fs.ensureDir(parent)

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -124,17 +124,17 @@ const platformName = () => {
   let name
 
   switch (original) {
-    case 'win32':
-      name = 'Windows'
-      break
     case 'darwin':
-      name = 'macOS'
+      name = 'now-macos'
+      break
+    case 'win32':
+      name = 'now-win.exe'
       break
     default:
       name = original
   }
 
-  return name
+  return `${name}.gz`
 }
 
 const canaryCheck = async () => {
@@ -289,7 +289,7 @@ exports.getURL = async () => {
   }
 
   const forPlatform = release.assets.find(
-    asset => asset.platform === platformName()
+    asset => asset.name === platformName()
   )
 
   if (!forPlatform) {

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -236,14 +236,20 @@ exports.handleExisting = async next => {
   const copyCommand = `${copyPrefix} ${next} ${destFile}`
 
   const why = 'To place Now CLI in the correct location.'
+  console.log(process)
 
   try {
     await fs.ensureDir(parent)
   } catch (err) {
     const dirPrefix = isWin ? 'md' : 'mkdir -p'
-    const dirCommand = `${dirPrefix} ${parent}`
 
-    await runAsRoot(`${dirCommand} && ${copyCommand}`, why)
+    const commands = [
+      `${dirPrefix} ${parent}`,
+      isWin ? `takeown /f ${parent} /r /d y` : `chown -R \`whoami\` ${parent}`,
+      copyCommand
+    ]
+
+    await runAsRoot(commands.join(' && '), why)
 
     await setPermissions()
     await ensurePath()

--- a/main/utils/binary.js
+++ b/main/utils/binary.js
@@ -242,11 +242,11 @@ exports.handleExisting = async next => {
   } catch (err) {
     const dirPrefix = isWin ? 'md' : 'mkdir -p'
 
-    const commands = [
-      `${dirPrefix} ${parent}`,
-      isWin ? `takeown /f ${parent} /r /d y` : `chown -R \`whoami\` ${parent}`,
-      copyCommand
-    ]
+    const commands = [`${dirPrefix} ${parent}`, copyCommand]
+
+    if (!isWin) {
+      commands.splice(1, 0, `chown -R \`whoami\` ${parent}`)
+    }
 
     await runAsRoot(commands.join(' && '), why)
 


### PR DESCRIPTION
After this PR, we're re-trying the automatic test that we're performing after downloading the binary 5 times. This way, we ensure the binary is really broken, not just temporarily inaccessible.