### PR TITLE
Don't reset scroll position when clicking team event

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -488,7 +488,7 @@ class Feed extends Component {
   setScopeWithSlug = slug => {
     const detected = this.detectScope('slug', slug)
 
-    if (detected) {
+    if (detected && this.state.scope !== detected.id) {
       this.setScope(detected.id)
     }
   }


### PR DESCRIPTION
**BEFORE**

<img src="https://user-images.githubusercontent.com/6170607/36624119-4ed7faf8-18c0-11e8-9800-d6e158593988.gif" width="400"/>

**AFTER**

<img src="https://user-images.githubusercontent.com/6170607/36624129-6679bc1e-18c0-11e8-9196-bcf3f3485bfe.gif" width="400"/>