### PR TITLE
Brought event types in sync with website

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -129,9 +129,11 @@ class Feed extends Component {
 
   getEventTypes() {
     const auto = new Set([
+      'scale',
       'scale-auto',
       'deployment-freeze',
-      'deployment-unfreeze'
+      'deployment-unfreeze',
+      'cert-autorenew'
     ])
 
     const all = new Set(messageComponents.keys())


### PR DESCRIPTION
We already have a user event when the scaling rules are changed,
`scale` event is then the actual scaling that may happen
immediately or later automatically due to system changes or
DC migration etc. `scale-auto` event is not sufficient for this
because it's solely reserved for the auto scaling feature.

Related to https://github.com/zeit/front/pull/1244.