### PR TITLE
Prevent menu from blocking renderer

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -173,7 +173,12 @@ app.on('ready', async () => {
       bounds.y = parseInt(bounds.y.toFixed(), 10) - bounds.height / 2
 
       const menu = await contextMenu(windows)
-      menu.popup(bounds.x, bounds.y)
+
+      menu.popup({
+        x: bounds.x,
+        y: bounds.y,
+        async: true
+      })
     }
   })
 

--- a/renderer/components/feed/event.js
+++ b/renderer/components/feed/event.js
@@ -50,7 +50,8 @@ class EventMessage extends PureComponent {
 
     this.menu.popup({
       x: event.clientX,
-      y: event.clientY
+      y: event.clientY,
+      async: true
     })
   }
 


### PR DESCRIPTION
Thanks to a suggestion by [Numaan](https://twitter.com/NumaanAshraf), I was able to prevent the hamburger menu from blocking the renderer thread! 🎉 

This means the events can be loaded even while that menu is open. 