### PR TITLE
Ensure artifacts are stored on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Bundling Application
           command: yarn build-app --publish 'never'
       - store_artifacts:
-          path: dist/*
+          path: dist
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
👋 

It seems CircleCI 2 doesn't accept `dist/*` as a path for artifacts. Checking now-desktop on CircleCI I noticed it had the same issue where it couldn't find files to upload as artifacts inside `dist/*`. I managed to fix the issue by removing `/*`. 🙌 

