### PR TITLE
Fixed message for deleted certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 
 # logs
 npm-debug.log
+yarn-error.log

--- a/renderer/components/feed/messages/cert-delete.js
+++ b/renderer/components/feed/messages/cert-delete.js
@@ -4,11 +4,12 @@ import Message from './message'
 export default class CertDelete extends Message {
   render() {
     const { event } = this.props
+    const { recordId } = event.payload
 
     return (
       <p>
         {this.getDisplayName()}
-        deleted a certificate for <b>{event.payload.cn}</b>
+        deleted certificate <b>{recordId}</b>
       </p>
     )
   }


### PR DESCRIPTION
BEFORE

<img width="466" alt="screen shot 2018-03-19 at 18 47 17" src="https://user-images.githubusercontent.com/6170607/37631817-8b53ee56-2ba8-11e8-9b2d-93020239be32.png">

AFTER

<img width="416" alt="screen shot 2018-03-19 at 19 06 12" src="https://user-images.githubusercontent.com/6170607/37631837-9d2c2670-2ba8-11e8-838d-b1fc27f5feba.png">

This also needs to be fixed on our website. On it! 🌷 