### PR TITLE
Prevent users getting logged out for no reason

### DIFF
--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -276,10 +276,15 @@ exports.watchConfig = async () => {
   configWatcher.on('unlink', async file => {
     let exists = true
 
+    // Be sure we get a path passed
+    if (!file) {
+      return
+    }
+
     // Be extra sure that it was removed, so that we
     // don't log out people for no reason
     try {
-      exists = file && (await pathExists(file))
+      exists = await pathExists(file)
     } catch (err) {
       console.error(err)
     }

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -274,9 +274,17 @@ exports.watchConfig = async () => {
 
   // Log out when a config file is removed
   configWatcher.on('unlink', async file => {
+    let exists = true
+
     // Be extra sure that it was removed, so that we
     // don't log out people for no reason
-    if (file && (await pathExists(file))) {
+    try {
+      exists = file && (await pathExists(file))
+    } catch (err) {
+      console.error(err)
+    }
+
+    if (exists) {
       return
     }
 

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -202,7 +202,7 @@ exports.saveConfig = async (data, type) => {
   })
 }
 
-const configChanged = async (file, logout) => {
+const configChanged = async file => {
   if (!global.windows || !configWatcher) {
     return
   }
@@ -218,7 +218,7 @@ const configChanged = async (file, logout) => {
   try {
     content = await exports.getConfig()
   } catch (err) {
-    logout('config-removed')
+    console.error(err)
     return
   }
 
@@ -270,7 +270,7 @@ exports.watchConfig = async () => {
   // Start watching the config file and
   // inform the renderer about changes inside it
   configWatcher = watch(toWatch)
-  configWatcher.on('change', file => configChanged(file, logout))
+  configWatcher.on('change', file => configChanged(file))
 
   // Log out when a config file is removed
   configWatcher.on('unlink', () => logout('config-removed'))

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -273,5 +273,13 @@ exports.watchConfig = async () => {
   configWatcher.on('change', file => configChanged(file))
 
   // Log out when a config file is removed
-  configWatcher.on('unlink', () => logout('config-removed'))
+  configWatcher.on('unlink', async file => {
+    // Be extra sure that it was removed, so that we
+    // don't log out people for no reason
+    if (file && (await pathExists(file))) {
+      return
+    }
+
+    logout('config-removed')
+  })
 }

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -274,7 +274,7 @@ exports.watchConfig = async () => {
 
   // Log out when a config file is removed
   configWatcher.on('unlink', async file => {
-    let exists = true
+    let exists = null
 
     // Be sure we get a path passed
     if (!file) {
@@ -287,6 +287,7 @@ exports.watchConfig = async () => {
       exists = await pathExists(file)
     } catch (err) {
       console.error(err)
+      return
     }
 
     if (exists) {


### PR DESCRIPTION
Previously, we were logging out the user if *any* form of error occurred while reading the configuration file after it was changed and the file system event triggered.

Now we're simply logging the error, because the config being not readable here is not important.

Furthermore, we were logging out the user if any config file was removed. This PR introduces an additional safety check and ensures the file actually doesn't exist anymore before triggering the logout.