### PR TITLE
Made event fetching in the background slower

### DIFF
--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -140,7 +140,7 @@ class Switcher extends Component {
     const { isVisible } = getCurrentWindow()
 
     const listTimer = () => {
-      const time = isVisible() ? '5s' : '60s'
+      const time = isVisible() ? '5s' : '5m'
 
       setTimeout(async () => {
         try {


### PR DESCRIPTION
Since we're updating the events immediately when the user opens the app, there's no reason to drain the battery and put too much load onto our servers.