### PR TITLE
Fixes main window positioning in different screens

### DIFF
--- a/main/utils/frames/list.js
+++ b/main/utils/frames/list.js
@@ -118,6 +118,8 @@ exports.mainWindow = tray => {
     }
   })
 
+  win.setVisibleOnAllWorkspaces(true)
+
   positionWindow(tray, win)
 
   win.loadURL(windowURL('feed'))


### PR DESCRIPTION
Fixes https://github.com/zeit/now-desktop/issues/463

It could close/re-open the window instead of hiding/showing, but that would be slower.

This allows it to show in all workspaces (including fullscreen), as it can be seen in the gif below:

![kapture 2018-04-12 at 14 50 49](https://user-images.githubusercontent.com/8822835/38697781-f15088c0-3e60-11e8-8808-690f34b7788c.gif)

