### PR TITLE
Load events correctly when switching teams from the CLI

### DIFF
--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -208,6 +208,9 @@ class Switcher extends Component {
         return
       }
 
+      // Load the teams in case there is a brand new team
+      await this.loadTeams()
+
       // Check for the `currentTeam` property in the config
       await this.checkCurrentTeam(config)
 


### PR DESCRIPTION
Fixes https://github.com/zeit/now-desktop/issues/468

After some investigation, it turns out that this happens when switching using the CLI to a team that didn't exist in the app so far. So it was trying to update the cache for a team that didn't have it and was getting these errors:
<img width="803" alt="screen shot 2018-04-16 at 11 06 33" src="https://user-images.githubusercontent.com/8822835/38819220-cef1d666-4168-11e8-8dd9-b849c9877822.png">

Loading the teams before updating the current team when listening to the config changes solved the issue.

This indirectly also solved the issue that when you switch the team in the manner described above, the avatar wouldn't appear in the list right away.