### PR TITLE
Force teams to update on window show

### DIFF
--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -107,6 +107,12 @@ class Switcher extends Component {
     currentWindow.on('show', () => {
       if (this.timer && this.state.syncInterval !== '5s') {
         clearInterval(this.timer)
+
+        // Refresh the teams and events when the window gets
+        // shown, so that they're always up-to-date
+        this.loadTeams()
+
+        // Restart the timer so we keep everything in sync every 5s
         this.listTimer()
         this.setState({ syncInterval: '5s' })
       }
@@ -117,6 +123,8 @@ class Switcher extends Component {
     currentWindow.on('hide', () => {
       if (this.timer && this.state.syncInterval !== '5m') {
         clearInterval(this.timer)
+
+        // Restart the timer so we keep everything in sync every 5m
         this.listTimer()
         this.setState({ syncInterval: '5m' })
       }

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -427,15 +427,6 @@ class Feed extends Component {
       // Ensure that scrolling position only gets
       // resetted if the window was closed for 5 seconds
       clearTimeout(scrollTimer)
-
-      // Get the currently active scope
-      const { scope, teams } = this.state
-
-      // Refresh the events when the window gets
-      // shown, so that they're always up-to-date
-      if (scope && teams.length > 0 && !this.loading.has(scope)) {
-        this.cacheEvents(scope, null, true)
-      }
     })
 
     currentWindow.on('hide', () => {


### PR DESCRIPTION
This will force the teams to be refreshed when the app is shown without waiting for the 5s timer to refresh, also triggering the refresh of the event , making sure that it also gets synced with the `now` cli. 

(people can show and hide the app in less than 5s which fail to refresh the teams on the cli)