### PR TITLE
Fix unknown event crash

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -552,6 +552,10 @@ class Feed extends Component {
     const events = list[group].map(item => {
       const MessageComponent = messageComponents.get(item.type)
 
+      if (!MessageComponent) {
+        return null
+      }
+
       const args = {
         event: item,
         user: this.state.currentUser,


### PR DESCRIPTION
@timothyis reported this bug on Slack. The API might send an event that we're unaware of, and if that happens, we shouldn't crash but simply skip displaying that event.