### PR TITLE
add queue to save config while switching teams

### DIFF
--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -38,7 +38,8 @@ class Switcher extends Component {
     updateFailed: false,
     online: true,
     initialized: false,
-    syncInterval: '5s'
+    syncInterval: '5s',
+    queue: []
   }
 
   remote = electron.remote || false
@@ -469,6 +470,10 @@ class Switcher extends Component {
       this.updateTouchBar()
     }
 
+    while (this.state.queue.length > 0) {
+      this.state.queue.shift()()
+    }
+
     if (this.state.initialized) {
       return
     }
@@ -555,7 +560,17 @@ class Switcher extends Component {
 
     // Save the new `currentTeam` to the config
     if (saveToConfig) {
-      this.updateConfig(team, byHand)
+      const queueFunction = (fn, context, params) => {
+        return () => {
+          fn.apply(context, params)
+        }
+      }
+
+      this.setState({
+        queue: this.state.queue.concat([
+          queueFunction(this.updateConfig, this, [team, byHand])
+        ])
+      })
     }
   }
 

--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -471,7 +471,11 @@ class Switcher extends Component {
     }
 
     while (this.state.queue.length > 0) {
-      this.state.queue.shift()()
+      const queue = this.state.queue
+
+      queue.shift()()
+
+      this.setState({ queue })
     }
 
     if (this.state.initialized) {


### PR DESCRIPTION
This fixes an issue by switching teams very fast, they get jumpy because of the sync with the file system and the refresh. What do you think @leo is this too crazy lol?

Jumpy
https://d.pr/i/kMkjan

Not Jumpy
https://d.pr/i/p21gCZ