### PR TITLE
Fix Deploy on Paste

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -343,6 +343,11 @@ class Feed extends Component {
       currentWindow.webContents.openDevTools()
     }
 
+    if (keyCode === 86 && metaKey) {
+      const { deploy } = this.remote.require('./utils/deploy-from-clipboard')
+      deploy()
+    }
+
     if (event.keyCode !== 27) {
       return
     }
@@ -407,7 +412,7 @@ class Feed extends Component {
     }
 
     const { getConfig } = this.remote.require('./utils/config')
-    const { deploy } = this.remote.require('./utils/deploy-from-clipboard')
+
     const config = await getConfig()
 
     this.setState({
@@ -420,9 +425,6 @@ class Feed extends Component {
 
     // And then allow hiding the windows using the keyboard
     document.addEventListener('keydown', this.onKeyDown)
-
-    // Propogate a clipoard 'paste' event down to the native implementation
-    document.addEventListener('paste', () => deploy())
 
     const currentWindow = this.remote.getCurrentWindow()
     let scrollTimer


### PR DESCRIPTION
While deploy on paste works correctly in dev mode (i.e. running this using `yarn start`), it fails when packaged because `electron` doesn't automatically register accelerators like Cmd+V (which it does in development mode). So, we can't rely on the `paste` event without registering an accelerator, and we can't register an accelerator without a visible menu (https://github.com/electron/electron/issues/1334)

Easiest solution seems to be directly hooking into `Cmd+V`