### PR TITLE
fix and improve multi word search highlight

### DIFF
--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -567,6 +567,8 @@ class Feed extends Component {
         const found = []
         const text = strip(markup)
 
+        keywords.sort((a, b) => b.length - a.length)
+
         for (const word of keywords) {
           // Check if the event message contains the keyword
           // and ignore the case
@@ -577,17 +579,16 @@ class Feed extends Component {
 
           found.push(true)
 
-          markup = markup.replace(new RegExp(word, 'gi'), (match, offset) => {
-            const before = markup.charAt(offset - 1)
-
-            // Don't replace HTML elements
-            if (before === '<' || before === '/') {
-              return match
+          markup = markup.replace(
+            new RegExp(
+              '(?!<mark[^>]*?>)(' + word + ')(?![^<]*?</mark>)(?![^<]*>)',
+              'gi'
+            ),
+            match => {
+              // Highlight the text we've found
+              return `<mark>${match}</mark>`
             }
-
-            // Highlight the text we've found
-            return `<mark>${match}</mark>`
-          })
+          )
         }
 
         // Don't include event if it doesn't contain any keywords


### PR DESCRIPTION
Searching while using multi words causes an render exception:

![2018-07-23 21 34 27](https://user-images.githubusercontent.com/1803556/43113515-4cbf8dfa-8ec0-11e8-99d6-a5856a14fbf9.gif)

Also I've improved the search highlight a little bit for multiple words.

![2018-07-23 21 30 59](https://user-images.githubusercontent.com/1803556/43113514-4ca88254-8ec0-11e8-85ad-0987d51f3ff9.gif)
