### PR TITLE
Fix crash when no OS field is present in User Agent

### DIFF
--- a/renderer/components/feed/messages/login.js
+++ b/renderer/components/feed/messages/login.js
@@ -27,7 +27,7 @@ export default class Login extends Message {
       from = userAgent.browser
         ? userAgent.browser.name
         : userAgent.program ? 'Now CLI' : null
-      os = osNames[userAgent.os.name] || userAgent.os.name
+      os = userAgent.os ? osNames[userAgent.os.name] || userAgent.os.name : null
     } else {
       from = payload.env
       os = payload.os


### PR DESCRIPTION
This PR fixes "An unexpected error has occurred" error that will be thrown when it tries to display a login message for an event where no `userAgent.os` is present
An app that authenticates via API (with React Native through `fetch` for example) will likely produce a login event without `userAgent.os`