### PR TITLE
Add support for mobile login events

### DIFF
--- a/renderer/components/feed/messages/login.js
+++ b/renderer/components/feed/messages/login.js
@@ -10,8 +10,13 @@ const osNames = {
   linux: 'Linux',
   freebsd: 'FreeBSD',
   sunos: 'SunOS',
-  'Mac OS': 'macOS'
+  'Mac OS': 'macOS',
+  ios: 'iOS',
+  android: 'Android'
 }
+
+const isMobile = ua =>
+  ua.includes('now-mobile') || ua.includes('CFNetwork') || ua.includes('okhttp')
 
 export default class Login extends Message {
   render() {
@@ -26,6 +31,8 @@ export default class Login extends Message {
     if (userAgent) {
       if (userAgent.ua && userAgent.ua.includes('Electron/')) {
         from = 'Now Desktop'
+      } else if (userAgent.ua && isMobile(userAgent.ua)) {
+        from = 'Now Mobile'
       } else {
         from = userAgent.browser
           ? userAgent.browser.name

--- a/renderer/utils/user-agent.js
+++ b/renderer/utils/user-agent.js
@@ -7,12 +7,24 @@ export default function parse(ua) {
   if (!parsed.browser.name && isNowCLI(ua)) {
     return parseNowCLI(ua)
   }
+  if (!parsed.browser.name && isNowMobile(ua)) {
+    return parseNowMobile(ua)
+  }
 
   return parsed
 }
 
 function isNowCLI(ua) {
   return ua.startsWith('now ')
+}
+
+function isNowMobile(ua) {
+  // Both new and v1.0.x
+  return (
+    ua.startsWith('now-mobile') ||
+    ua.includes('CFNetwork') ||
+    ua.startsWith('okhttp')
+  )
 }
 
 const regexps = {
@@ -38,4 +50,24 @@ function parseNowCLI(ua) {
   })
 
   return parsed
+}
+
+function parseNowMobile(ua) {
+  // 1.0.x user agents
+  const legacy = ua.includes('CFNetwork') || ua.startsWith('okhttp')
+  if (legacy) {
+    return {
+      ua,
+      version: '1.0.3',
+      os: { name: ua.includes('CFNetwork') ? 'ios' : 'android' }
+    }
+  }
+
+  // New user agents have the 'now-mobile/<version>/<os>' format
+  const [, version, os] = ua.replace(/ /g, '').split('/')
+  return {
+    ua,
+    version,
+    os: { name: os }
+  }
 }


### PR DESCRIPTION
An addition to #509, this PR adds support for full login messages for Now Mobile.
It supports both v1.0.x user agents (the ones that broke everything initially) as well as the new nicer ones coming soon in v1.1.0 release