### PR TITLE
Fixed wrong script name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ brew cask install now
 To make sure that your code works in the bundled application, you can generate the binaries like this:
 
 ```bash
-yarn run pack
+yarn run build
 ```
 
 After that, you'll find them in the `./dist` folder!


### PR DESCRIPTION
`pack` script removed here: https://github.com/zeit/now-desktop/commit/edfe3d8bcad7c922021f1b7d7f29ae3ca6e19278#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

to `build` here: https://github.com/zeit/now-desktop/commit/e5b7f77ae128edde08b0fe45ebf0b0cc05f076c6#diff-b9cfc7f2cdf78a7f4b91a753d10865a2