### PR TITLE
Reset scope if a team gets deleted

### DIFF
--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -276,7 +276,16 @@ class Switcher extends Component {
       return
     }
 
-    this.changeScope(config.currentTeam, true)
+    const { teams } = await loadData(API_TEAMS)
+    const related = teams.find(team => team.id === config.currentTeam)
+
+    // The team was deleted
+    if (!related) {
+      this.resetScope()
+      return
+    }
+
+    this.changeScope(related, true)
   }
 
   async saveConfig(newConfig) {


### PR DESCRIPTION
This bug is remaining from https://github.com/zeit/now-desktop/pull/526 and ensures we correctly set the scope based on `currentTeam` and reset the scope if a team gets deleted.