### PR TITLE
stop using editorconfig with prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "lint-staged": {
     "*.js": [
       "yarn test-lint",
-      "prettier --single-quote --no-semi --write",
+      "prettier --single-quote --no-semi --write --no-editorconfig",
       "git add"
     ]
   },


### PR DESCRIPTION
Fixes: 
```
husky > npm run -s precommit (node v8.11.1)

 ❯ Running tasks for *.js
   ✔ yarn test-lint
   ✖ prettier --single-quote --no-semi --write
     git add
✖ "prettier --single-quote --no-semi --write" found some errors. Please fix them and try committing again.

[error] Unable to expand glob patterns: {DIR}/{FILES}.js !**/node_modules/** !./node_modules/**
[error] Invalid `"printWidth"` value. Expected an integer, but received `null`.

husky > pre-commit hook failed (add --no-verify to bypass)
```