### PR TITLE
Avoid the CLI having to migrate again

### DIFF
--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -178,12 +178,9 @@ exports.saveConfig = async (data, type) => {
       }
     }
 
-    if (
-      typeof currentContent.user === 'string' ||
-      typeof currentContent.currentTeam === 'string'
-    ) {
-      if (typeof data.user === 'object') {
-        data.user = data.user.uid || data.user.id
+    if (!currentContent.sh) {
+      if (typeof data.user !== 'undefined') {
+        delete data.user
       }
 
       if (typeof data.currentTeam === 'object') {


### PR DESCRIPTION
Currently, you will see a lot of migration messages from Now CLI, because every time Now CLI removes useless information from the config, Now Desktop is adding it again.

This fixes the message from showing up all the time.