### PR TITLE
When logging in, default to widely supported config

### DIFF
--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -127,7 +127,7 @@ exports.removeConfig = async () => {
   })
 }
 
-exports.saveConfig = async (data, type) => {
+exports.saveConfig = async (data, type, firstSave = false) => {
   const destination = paths[type]
   let currentContent = {}
 
@@ -137,6 +137,10 @@ exports.saveConfig = async (data, type) => {
 
   if (type === 'config') {
     let existingShownTips = currentContent.shownTips
+
+    if (firstSave && typeof currentContent.sh === 'undefined') {
+      currentContent.sh = {}
+    }
 
     if (currentContent.sh) {
       // These are top-level properties
@@ -216,6 +220,10 @@ exports.saveConfig = async (data, type) => {
     if (!currentContent._) {
       currentContent._ =
         "This is your Now credentials file. DON'T SHARE! More: https://git.io/v5ECz"
+    }
+
+    if (firstSave && typeof currentContent.credentials === 'undefined') {
+      currentContent.credentials = []
     }
 
     if (currentContent.credentials) {

--- a/renderer/components/tutorial/login.js
+++ b/renderer/components/tutorial/login.js
@@ -250,7 +250,8 @@ class LoginForm extends PureComponent {
             email: user.email
           }
         },
-        'config'
+        'config',
+        true
       )
     } catch (err) {
       error('Could not save main config', err)
@@ -263,7 +264,8 @@ class LoginForm extends PureComponent {
           provider: 'sh',
           token: finalToken
         },
-        'auth'
+        'auth',
+        true
       )
     } catch (err) {
       error('Could not save auth config', err)


### PR DESCRIPTION
The previous [4.0.1](https://github.com/zeit/now-desktop/releases/tag/4.0.1) sadly made the assumption that the user expected the new config by default, without even beeing sure that they are running the latest Now CLI.

With this PR, we make sure that we save a format of the config on login that is supported by any version of Now Desktop and Now CLI. This way, we guarantee that it works.

Then, if needed, any of the new clients the user installs can migrate the config on their own.