### PR TITLE
Make deploying consider `currentTeam` again

### DIFF
--- a/main/utils/deploy/index.js
+++ b/main/utils/deploy/index.js
@@ -327,7 +327,10 @@ class Now extends EventEmitter {
     if (!opts.useCurrentTeam && this.currentTeam) {
       const parsedUrl = parseUrl(_url, true)
       const query = parsedUrl.query
-      query.teamId = this.currentTeam.id
+      query.teamId =
+        typeof this.currentTeam === 'string'
+          ? this.currentTeam
+          : this.currentTeam.id
       _url = `${parsedUrl.pathname}?${qs.encode(query)}`
       delete opts.useCurrentTeam
     }


### PR DESCRIPTION
In some case, the `currentTeam` config property might be just the ID and not an entire object of data about the team. With this PR, we cover that case.