### PR TITLE
Only track online state in one place

### DIFF
--- a/renderer/components/feed/switcher.js
+++ b/renderer/components/feed/switcher.js
@@ -506,6 +506,18 @@ class Switcher extends Component {
     }, when)
   }
 
+  static getDerivedStateFromProps(props) {
+    // Ensure that the animations for the teams
+    // fading in works after recovering from offline mode.
+    if (!props.online) {
+      return {
+        initialized: false
+      }
+    }
+
+    return null
+  }
+
   async updateConfig(team, updateMessage) {
     if (!this.remote) {
       return

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -494,6 +494,7 @@ class Feed extends Component {
     }
 
     document.removeEventListener('keydown', this.onKeyDown)
+
     this.ipcRenderer.removeListener('config-changed', this.onConfigChanged)
     this.ipcRenderer.removeListener('theme-changed', this.onThemeChanged)
   }
@@ -865,7 +866,7 @@ class Feed extends Component {
             setTeams={this.setTeams}
             currentUser={this.state.currentUser}
             titleRef={this.title}
-            onlineStateFeed={this.setOnlineState}
+            online={this.state.online}
             activeScope={activeScope}
             darkBg={this.state.darkMode}
           />


### PR DESCRIPTION
This prevents a number of errors when the both state of the `Feed` and the `Switcher` are not in sync.