### PR TITLE
Report crashes to Sentry

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -8,6 +8,7 @@ const squirrelStartup = require('electron-squirrel-startup')
 const Sentry = require('@sentry/electron')
 
 // Utilities
+const pkg = require('../package')
 const firstRun = require('./utils/first-run')
 const { innerMenu, outerMenu } = require('./menu')
 const { error: showError } = require('./dialogs')
@@ -18,9 +19,14 @@ const windowList = require('./utils/frames/list')
 const { getConfig, watchConfig } = require('./utils/config')
 const { exception: handleException } = require('./utils/error')
 
-Sentry.init({
-  dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140'
-})
+// In development, we do not want to report errors
+if (!isDev) {
+  Sentry.init({
+    dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140',
+    environment: pkg.includes('canary') ? 'canary' : 'stable',
+    release: `now-desktop@${pkg.version}`
+  })
+}
 
 // Immediately quit the app if squirrel is launching it
 if (squirrelStartup) {
@@ -56,8 +62,18 @@ const { app } = electron
 // Set the application's name
 app.setName('Now')
 
-// Handle uncaught exceptions
-process.on('uncaughtException', handleException)
+const reportAndHandle = err => {
+  if (isDev) {
+    return
+  }
+
+  Sentry.captureException(err)
+  handleException()
+}
+
+// Handle uncaught exceptions and rejections
+process.on('uncaughtException', reportAndHandle)
+process.on('unhandledRejection', reportAndHandle)
 
 // Hide dock icon before the app starts
 // This is only required for development because

--- a/main/index.js
+++ b/main/index.js
@@ -62,12 +62,21 @@ const { app } = electron
 // Set the application's name
 app.setName('Now')
 
-const reportAndHandle = err => {
+const reportAndHandle = async err => {
   if (isDev) {
     return
   }
 
   Sentry.captureException(err)
+
+  const client = Sentry.getCurrentHub().getClient()
+
+  if (client) {
+    // Block execution until the error is sent. This ensures
+    // we only relaunch the app once the error was reported to ZEIT.
+    await client.close()
+  }
+
   handleException()
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Create deployments right from the tray menu",
   "version": "4.0.0-canary.79",
   "author": {
-    "name": "Zeit, Inc.",
+    "name": "ZEIT Inc.",
     "email": "team@zeit.co"
   },
   "repository": "zeit/now-desktop",

--- a/renderer/pages/_error.js
+++ b/renderer/pages/_error.js
@@ -2,15 +2,25 @@ import * as Sentry from '@sentry/electron'
 import React from 'react'
 import Error from 'next/error'
 import PropTypes from 'prop-types'
+import isDev from 'electron-is-dev'
+import pkg from '../../package'
 
-Sentry.init({
-  dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140'
-})
+if (!isDev) {
+  Sentry.init({
+    dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140',
+    environment: pkg.includes('canary') ? 'canary' : 'stable',
+    release: `now-desktop@${pkg.version}`
+  })
+}
 
 class ErrorPage extends React.Component {
   static getInitialProps({ res, err }) {
     const statusCode = res ? res.statusCode : err ? err.statusCode : null
-    Sentry.captureException(err)
+
+    if (!isDev) {
+      Sentry.captureException(err)
+    }
+
     return { statusCode }
   }
 


### PR DESCRIPTION
After this PR, now Desktop will report crashes to Sentry before relaunching the app.

It also adds `release` and `environment` properties to the errors.