### PR TITLE
Do not restart for unhandled rejections

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -82,7 +82,6 @@ const reportAndHandle = async err => {
 
 // Handle uncaught exceptions and rejections
 process.on('uncaughtException', reportAndHandle)
-process.on('unhandledRejection', reportAndHandle)
 
 // Hide dock icon before the app starts
 // This is only required for development because


### PR DESCRIPTION
As we discovered today, there seems to be a Electron-native [unhandled rejection](https://sentry.io/zeithq/now-desktop/issues/812188270/?referrer=slack) that will occur if a crash dump could not be read/saved.

Because I made Now Desktop recover from unhandled rejections earlier today in https://github.com/zeit/now-desktop/pull/578, this just caused an infinite loop for a user. In turn, we need to remove it again. 