### PR TITLE
Add error boundary for all events

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -19,7 +19,7 @@ const { getConfig, watchConfig } = require('./utils/config')
 const { exception: handleException } = require('./utils/error')
 
 Sentry.init({
-  dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140'
+  dsn: require('../package.json').sentryDsn
 })
 
 // Immediately quit the app if squirrel is launching it

--- a/main/index.js
+++ b/main/index.js
@@ -6,6 +6,7 @@ const prepareNext = require('electron-next')
 const { resolve: resolvePath } = require('app-root-path')
 const squirrelStartup = require('electron-squirrel-startup')
 const Sentry = require('@sentry/electron')
+const { sentryDsn } = require('../package.json')
 
 // Utilities
 const firstRun = require('./utils/first-run')
@@ -19,7 +20,7 @@ const { getConfig, watchConfig } = require('./utils/config')
 const { exception: handleException } = require('./utils/error')
 
 Sentry.init({
-  dsn: require('../package.json').sentryDsn
+  dsn: sentryDsn
 })
 
 // Immediately quit the app if squirrel is launching it

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "yarn test-lint",
     "test-lint": "xo"
   },
+  "sentryDsn": "https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140",
   "build": {
     "appId": "co.zeit.now",
     "files": [

--- a/renderer/components/feed/event.js
+++ b/renderer/components/feed/event.js
@@ -5,6 +5,7 @@ import { object, func, string, bool } from 'prop-types'
 import dotProp from 'dot-prop'
 import ms from 'ms'
 import * as Sentry from '@sentry/electron'
+import pkg from '../../../package'
 
 // Styles
 import { localStyles, globalStyles } from '../../styles/components/feed/event'
@@ -16,9 +17,7 @@ import dateDiff from '../../utils/date-diff'
 import Avatar from './avatar'
 
 Sentry.init({
-  dsn: electron.remote
-    ? electron.remote.require('../package.json').sentryDsn
-    : null
+  dsn: pkg.sentryDsn
 })
 
 class EventMessage extends PureComponent {

--- a/renderer/components/feed/event.js
+++ b/renderer/components/feed/event.js
@@ -16,7 +16,9 @@ import dateDiff from '../../utils/date-diff'
 import Avatar from './avatar'
 
 Sentry.init({
-  dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140'
+  dsn: electron.remote
+    ? electron.remote.require('../package.json').sentryDsn
+    : null
 })
 
 class EventMessage extends PureComponent {

--- a/renderer/components/feed/event.js
+++ b/renderer/components/feed/event.js
@@ -16,9 +16,13 @@ import dateDiff from '../../utils/date-diff'
 // Components
 import Avatar from './avatar'
 
-Sentry.init({
-  dsn: pkg.sentryDsn
-})
+// Check if this is on the client,
+// since the build won't work otherwise
+if (typeof window !== 'undefined') {
+  Sentry.init({
+    dsn: pkg.sentryDsn
+  })
+}
 
 class EventMessage extends PureComponent {
   state = {

--- a/renderer/pages/_error.js
+++ b/renderer/pages/_error.js
@@ -1,13 +1,11 @@
-import electron from 'electron'
 import * as Sentry from '@sentry/electron'
 import React from 'react'
 import Error from 'next/error'
 import PropTypes from 'prop-types'
+import pkg from '../../package'
 
 Sentry.init({
-  dsn: electron.remote
-    ? electron.remote.require('../package.json').sentryDsn
-    : null
+  dsn: pkg.sentryDsn
 })
 
 class ErrorPage extends React.Component {

--- a/renderer/pages/_error.js
+++ b/renderer/pages/_error.js
@@ -1,10 +1,13 @@
+import electron from 'electron'
 import * as Sentry from '@sentry/electron'
 import React from 'react'
 import Error from 'next/error'
 import PropTypes from 'prop-types'
 
 Sentry.init({
-  dsn: 'https://d07ceda63dd8414e9c403388cfbd18fe@sentry.io/1323140'
+  dsn: electron.remote
+    ? electron.remote.require('../package.json').sentryDsn
+    : null
 })
 
 class ErrorPage extends React.Component {


### PR DESCRIPTION
This will prevent Now Desktop from crashing if an event should have an invalid payload or any other error.

Errors will be reported to sentry and logged to the console.