### PR TITLE
Reset state after invalid email was entered

### DIFF
--- a/renderer/components/tutorial/login.js
+++ b/renderer/components/tutorial/login.js
@@ -240,7 +240,12 @@ class LoginForm extends PureComponent {
           error('Failed to verify login. Please retry later.', err);
         }
 
-        break;
+        this.props.setIntroState({
+          classes: [],
+          security: null
+        });
+
+        return;
       }
 
       console.log('Waiting for token...')


### PR DESCRIPTION
This is a follow-up to https://github.com/zeit/now-desktop/pull/608 and allows people to type a different email if their previous one was invalid.