### PR TITLE
Handle domain move and transfer-in events

### DIFF
--- a/renderer/components/feed/messages/domain-move-in.js
+++ b/renderer/components/feed/messages/domain-move-in.js
@@ -1,0 +1,14 @@
+import Message from './message'
+
+export default class DomainMoveIn extends Message {
+  render() {
+    const { payload } = this.props.event
+    return (
+      <p>
+        {this.getDisplayName()}
+        moved in domain <b>{payload.name}</b>
+        {payload.fromName ? ` from ${payload.fromName}` : ''}
+      </p>
+    )
+  }
+}

--- a/renderer/components/feed/messages/domain-move-out-request-sent.js
+++ b/renderer/components/feed/messages/domain-move-out-request-sent.js
@@ -1,0 +1,15 @@
+import Message from './message'
+
+export default class DomainMoveOutRequestSent extends Message {
+  render() {
+    const { payload } = this.props.event
+    return (
+      <p>
+        {this.getDisplayName()}
+        sent a move domain <b>{payload.name}</b> request{payload.destinationName
+          ? ` to ${payload.destinationName}`
+          : ''}
+      </p>
+    )
+  }
+}

--- a/renderer/components/feed/messages/domain-move-out.js
+++ b/renderer/components/feed/messages/domain-move-out.js
@@ -1,0 +1,14 @@
+import Message from './message'
+
+export default class DomainMoveOut extends Message {
+  render() {
+    const { payload } = this.props.event
+    return (
+      <p>
+        {this.getDisplayName()}
+        moved domain <b>{payload.name}</b>
+        {payload.destinationName ? ` to ${payload.destinationName}` : ` out`}
+      </p>
+    )
+  }
+}

--- a/renderer/components/feed/messages/domain-transfer-in-canceled.js
+++ b/renderer/components/feed/messages/domain-transfer-in-canceled.js
@@ -1,0 +1,12 @@
+import Message from './message'
+
+export default class DomainTransferInCanceled extends Message {
+  render() {
+    const { payload } = this.props.event
+    return (
+      <p>
+        canceled domain <b>{payload.name}</b> transfer
+      </p>
+    )
+  }
+}

--- a/renderer/components/feed/messages/domain-transfer-in-completed.js
+++ b/renderer/components/feed/messages/domain-transfer-in-completed.js
@@ -1,0 +1,12 @@
+import Message from './message'
+
+export default class DomainTransferInCompleted extends Message {
+  render() {
+    const { payload } = this.props.event
+    return (
+      <p>
+        completed domain <b>{payload.name}</b> transfer
+      </p>
+    )
+  }
+}

--- a/renderer/components/feed/messages/domain-transfer-in.js
+++ b/renderer/components/feed/messages/domain-transfer-in.js
@@ -1,0 +1,14 @@
+import Message from './message'
+
+export default class DomainTransferIn extends Message {
+  render() {
+    const { payload } = this.props.event
+    return (
+      <p>
+        {this.getDisplayName()}
+        initiated domain transfer for <b>{payload.name}</b>{' '}
+        {payload.price ? `($${payload.price})` : ''}
+      </p>
+    )
+  }
+}

--- a/renderer/components/feed/messages/index.js
+++ b/renderer/components/feed/messages/index.js
@@ -22,6 +22,12 @@ import Domain from './domain'
 import DomainBuy from './domain-buy'
 import DomainChown from './domain-chown'
 import DomainDelete from './domain-delete'
+import DomainMoveIn from './domain-move-in'
+import DomainMoveOut from './domain-move-out'
+import DomainMoveOutRequestSent from './domain-move-out-request-sent'
+import DomainTransferIn from './domain-transfer-in'
+import DomainTransferInCanceled from './domain-transfer-in-canceled'
+import DomainTransferInCompleted from './domain-transfer-in-completed'
 import Login from './login'
 import Plan from './plan'
 import Scale from './scale'
@@ -66,6 +72,12 @@ export default new Map([
   ['deployment-unfreeze', DeploymentUnfreeze],
   ['domain-chown', DomainChown],
   ['domain-delete', DomainDelete],
+  ['domain-move-in', DomainMoveIn],
+  ['domain-move-out-request-sent', DomainMoveOutRequestSent],
+  ['domain-move-out', DomainMoveOut],
+  ['domain-transfer-in-canceled', DomainTransferInCanceled],
+  ['domain-transfer-in-completed', DomainTransferInCompleted],
+  ['domain-transfer-in', DomainTransferIn],
   ['login', Login],
   ['plan', Plan],
   ['scale', Scale],

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -135,7 +135,9 @@ class Feed extends Component {
       'deployment-freeze',
       'deployment-unfreeze',
       'cert-autorenew',
-      'alias-system'
+      'alias-system',
+      'domain-transfer-in-canceled',
+      'domain-transfer-in-completed'
     ])
 
     const all = new Set(messageComponents.keys())


### PR DESCRIPTION
Adds the following user events:
- [x] handle `domain-move-out`
- [x] handle `domain-move-in`
- [x] handle `domain-move-out-request-sent`
- [x] handle `domain-transfer-in` event

And the following system events:
- [x] handle `domain-transfer-in-complete` event
- [x] handle `domain-transfer-in-canceled` event
