### PR TITLE
Hide top border when month header reaches the top

### DIFF
--- a/renderer/components/events.js
+++ b/renderer/components/events.js
@@ -161,10 +161,6 @@ const renderEvents = (
           border-bottom: 1px solid #000;
           border-top: 1px solid #000;
         }
-
-        h1:first-child {
-          border-top: 0;
-        }
       `}</style>
     </h1>,
     months[month].map(event => (
@@ -357,6 +353,7 @@ const Events = ({ online, darkMode, scopes, setConfig, active, config }) => {
           cursor: default;
           flex-shrink: 1;
           position: relative;
+          margin-top: -1px;
         }
 
         section.dark {


### PR DESCRIPTION
Fixes #620 

Before:
![Screen Shot 2019-04-19 at 9 18 18 AM](https://user-images.githubusercontent.com/8822835/56427560-599d4a00-628a-11e9-964a-25fca806080c.png)

After:
![Screen Shot 2019-04-19 at 9 18 05 AM](https://user-images.githubusercontent.com/8822835/56427565-5f932b00-628a-11e9-961e-b4738dc94979.png)
