### PR TITLE
Update listeners when scopes change

### DIFF
--- a/renderer/components/switcher.js
+++ b/renderer/components/switcher.js
@@ -297,9 +297,7 @@ const Switcher = ({ online, darkMode, scopes, active, config, setConfig }) => {
         document.removeEventListener('keydown', handleOnKeyDown);
       };
     },
-
-    // Never re-invoke this effect
-    []
+    [JSON.stringify(scopes)]
   );
 
   return (


### PR DESCRIPTION
While investigating #618 I noticed that you can't use the number keys (1,2,3 etc) to navigate between the teams, even though the logic was in the codebase. Clicking any number showed the following error while trying to access `scopes.length`:

```
Uncaught TypeError: Cannot read property 'length' of null
    at feed.js:1
    at HTMLDocument.e (feed.js:1)
```

The effect that adds the keyboard event was not being called again when `scopes` was fetched. Running the effect again when `scopes` changes fixed it