### PR TITLE
Sort scopes alphabetically and fix avatars in dark mode

### DIFF
--- a/renderer/components/avatar.js
+++ b/renderer/components/avatar.js
@@ -107,7 +107,7 @@ const Avatar = ({ darkMode, scale, delay, event, scope, hash }) => {
         }
 
         .darkMode {
-          border: 1px solid #fff;
+          border: 1px solid #444;
         }
 
         .scale {

--- a/renderer/effects/scopes.js
+++ b/renderer/effects/scopes.js
@@ -27,6 +27,13 @@ export default ({ token }, setScopes) => {
 
           const { user } = data;
 
+          scopes.sort((a, b) => {
+            if (a.slug < b.slug) return -1;
+            if (a.slug > b.slug) return 1;
+
+            return 0;
+          });
+
           scopes.unshift({
             id: user.uid,
             avatar: user.avatar,

--- a/renderer/memos/scope-order.js
+++ b/renderer/memos/scope-order.js
@@ -1,7 +1,7 @@
 import makeUnique from 'make-unique';
 
 const merge = (first, second) => {
-  const merged = first.concat(second);
+  const merged = first.concat(second).filter(Boolean);
   return makeUnique(merged, (a, b) => a.id === b.id);
 };
 


### PR DESCRIPTION
This PR enforces scopes order in the format consistent with `zeit.co`