### PR TITLE
Fix `Preparing` glitch and upgrade now-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
     "node-fetch": "2.6.0",
-    "now-client": "3.5.0",
+    "now-client": "3.5.1",
     "path-exists": "4.0.0",
     "promisepipe": "3.0.0",
     "react-fast-compare": "2.0.4",

--- a/renderer/components/deployment-bar.js
+++ b/renderer/components/deployment-bar.js
@@ -43,10 +43,11 @@ const DeploymentBar = ({
       setHiding(false);
       setHidden(false);
     }
-  });
+  }, [activeDeployment, error]);
 
   const readyBuilds = builds.filter(build => build.readyState).length;
-  const progress = builds && builds > 0 ? readyBuilds / builds.length * 100 : 0;
+  const progress =
+    builds && builds > 0 ? (readyBuilds / builds.length) * 100 : 0;
 
   return hidden ? null : (
     <div className={`deployment-bar ${hiding ? 'hiding' : ''}`}>

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -132,9 +132,9 @@ const Main = ({ router }) => {
     setActiveDeployment(deployment);
 
     const handleError = err => {
-      setActiveDeployment(null);
       setActiveDeploymentBuilds([]);
       setDeploymentError(err);
+      setActiveDeployment(null);
     };
 
     deployment.on('error', handleError);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5781,10 +5781,10 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-now-client@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.5.0.tgz#9837dbdcb113d6210b2281249ebc63876cff3281"
-  integrity sha512-ZUHAXNvJa3o2y2dW6Y4sAO9v6FbnsadrliUQAk05uieXYEtcxI+qvP8Sk+057xQt1Jo2LVp9ngfLY9uKA0nlJQ==
+now-client@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.5.1.tgz#bad7ebcfa87136b547447df5ccf7199240246e2b"
+  integrity sha512-kJtLYSIZdMzKYXiqjtUUql/1z1tSvPylQOg5VQkYR262jN1SW09eOrpG3gG+H/FAWQR3Jh4l01iurjKH8rOFtA==
   dependencies:
     crypto-js "^3.1.9-1"
     ignore "^5.1.1"


### PR DESCRIPTION
This fixes a double showing of the `Preparing...` bar and upgrades `now-client` to fix a missing `.nowignore` bug