### PR TITLE
Make deploying smoother

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
     "node-fetch": "2.6.0",
-    "now-client": "3.7.1",
+    "now-client": "3.8.0",
     "path-exists": "4.0.0",
     "promisepipe": "3.0.0",
     "react-fast-compare": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
     "node-fetch": "2.6.0",
-    "now-client": "3.6.0",
+    "now-client": "3.7.0",
     "path-exists": "4.0.0",
     "promisepipe": "3.0.0",
     "react-fast-compare": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
     "node-fetch": "2.6.0",
-    "now-client": "3.7.0",
+    "now-client": "3.7.1",
     "path-exists": "4.0.0",
     "promisepipe": "3.0.0",
     "react-fast-compare": "2.0.4",

--- a/renderer/components/dropzone.js
+++ b/renderer/components/dropzone.js
@@ -60,7 +60,7 @@ const droppedFile = (e, hide, onDrop) => {
 
       // Handle dropped files
       if (onDrop) {
-        onDrop(files);
+        onDrop(files, initialPath.slice(1));
       }
     });
   } else if (onDrop) {

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -120,13 +120,14 @@ const Main = ({ router }) => {
     [JSON.stringify(scopeOrder), JSON.stringify(scopes)]
   );
 
-  const createDeployment = async files => {
+  const createDeployment = async (files, defaultName) => {
     if (!files || files.length === 0) {
       return;
     }
 
     const deployment = new Deployment(files, config.token, {
-      teamId: config.currentTeam
+      teamId: config.currentTeam,
+      defaultName
     });
 
     setDeploymentError(null);
@@ -194,7 +195,9 @@ const Main = ({ router }) => {
           <DropZone
             darkMode={darkMode}
             hide={() => setShowDropZone(false)}
-            onDrop={files => createDeployment(files)}
+            onDrop={(files, defaultName) =>
+              createDeployment(files, defaultName)
+            }
           />
         )}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5781,10 +5781,10 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-now-client@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.6.0.tgz#009490d7d922037a6a750def65fd63932cb1ec03"
-  integrity sha512-S7zzUTFwoEqyZaTo6gXMOyOdtIrIaBnUCAsGXX5bXQ1d6PTIL5vXd/0yGfyuDBh/vLRjAxMv/+lZz+ATXelVHg==
+now-client@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.7.0.tgz#c85f8f74fac9e4072f4b7da4d1ffccbc07e67681"
+  integrity sha512-EO+T/qKaSqnylP9p/u0GsLzGrtChfCxUUgVPQyv3bVBwNZNBACZzfCW+u4vnMlYu5a0VcshIOnhAcs7tii4hKw==
   dependencies:
     crypto-js "^3.1.9-1"
     ignore "^5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5781,10 +5781,10 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-now-client@3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.7.0.tgz#c85f8f74fac9e4072f4b7da4d1ffccbc07e67681"
-  integrity sha512-EO+T/qKaSqnylP9p/u0GsLzGrtChfCxUUgVPQyv3bVBwNZNBACZzfCW+u4vnMlYu5a0VcshIOnhAcs7tii4hKw==
+now-client@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.7.1.tgz#80e7ceee7e2e8b80366ad9570eb4361a7f175cae"
+  integrity sha512-GuXMMmyfxwlMh5TVcX7AGKLlQxoYPUQnHLzcpQ8EX4iRoPP9k7QvBjT4V0JSsw5otrc0hLKRN9S4AaO6+yizGg==
   dependencies:
     crypto-js "^3.1.9-1"
     ignore "^5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5781,10 +5781,10 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-now-client@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.7.1.tgz#80e7ceee7e2e8b80366ad9570eb4361a7f175cae"
-  integrity sha512-GuXMMmyfxwlMh5TVcX7AGKLlQxoYPUQnHLzcpQ8EX4iRoPP9k7QvBjT4V0JSsw5otrc0hLKRN9S4AaO6+yizGg==
+now-client@3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/now-client/-/now-client-3.8.0.tgz#5ceb87be7a58c519640aa9066852abc1bece0d25"
+  integrity sha512-4lWMRyqxGfbIyqmSZ9ioCdYfJ/PAMcjo55AKuePC2INIZckkoM0hHkLMC2U6SU3OpiW5je0uvQs2wNDHAZgIfg==
   dependencies:
     crypto-js "^3.1.9-1"
     ignore "^5.1.1"


### PR DESCRIPTION
Bump `now-client` to 3.7.0 which fixes the SHA1 error