### PR TITLE
Move about from page to component

### DIFF
--- a/renderer/components/about-screen.js
+++ b/renderer/components/about-screen.js
@@ -1,35 +1,17 @@
-import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import ms from 'ms';
 import semVer from 'semver';
-import darkModeEffect from '../effects/dark-mode';
-import configEffect from '../effects/config';
 import versionEffect from '../effects/version';
-import Title from '../components/title';
-import Spinner from '../components/spinner';
 import Logo from '../vectors/logo-about';
+import Title from './title';
+import Spinner from './spinner';
 
-const About = ({ router }) => {
-  const [config, setConfig] = useState(null);
-  const [darkMode, setDarkMode] = useState(router.query.darkMode || null);
+const About = ({ darkMode, config, onBackClick }) => {
   const [latestVersion, setLatestVersion] = useState(null);
-
-  useEffect(
-    () => {
-      return configEffect(config, setConfig);
-    },
-
-    // Never re-invoke this effect.
-    []
-  );
 
   useEffect(() => {
     return versionEffect(config, setLatestVersion);
-  });
-
-  useEffect(() => {
-    return darkModeEffect(darkMode, setDarkMode);
   });
 
   /* eslint-disable no-undef */
@@ -47,7 +29,7 @@ const About = ({ router }) => {
 
   return (
     <main className={darkMode ? 'dark' : ''}>
-      <Title darkMode={darkMode} title="About" />
+      <Title darkMode={darkMode} title="About" onBackClick={onBackClick} />
 
       <section>
         <Logo darkMode={darkMode} style={{ marginBottom: 20 }} />
@@ -238,7 +220,9 @@ const About = ({ router }) => {
 };
 
 About.propTypes = {
-  router: PropTypes.object
+  darkMode: PropTypes.bool,
+  config: PropTypes.object,
+  onBackClick: PropTypes.func
 };
 
-export default withRouter(About);
+export default About;

--- a/renderer/components/switcher.js
+++ b/renderer/components/switcher.js
@@ -1,6 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Router from 'next/router';
 import * as sortable from 'react-sortable-hoc';
 import ipc from '../utils/ipc';
 import CreateTeam from './create-team';
@@ -250,10 +249,17 @@ const openMenu = menu => {
   });
 };
 
-const Switcher = ({ online, darkMode, scopes, active, config, setConfig }) => {
+const Switcher = ({
+  online,
+  darkMode,
+  scopes,
+  active,
+  config,
+  setConfig,
+  disableScopesAnimation
+}) => {
   const [initialized, setInitialized] = useState(
-    typeof window !== 'undefined' &&
-      Boolean(Router.query.disableScopesAnimation)
+    Boolean(disableScopesAnimation)
   );
 
   const menu = useRef(null);
@@ -498,7 +504,8 @@ Switcher.propTypes = {
   active: PropTypes.object,
   config: PropTypes.object,
   scopes: PropTypes.array,
-  setConfig: PropTypes.func
+  setConfig: PropTypes.func,
+  disableScopesAnimation: PropTypes.bool
 };
 
 export default Switcher;

--- a/renderer/components/title.js
+++ b/renderer/components/title.js
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef } from 'react';
-import Link from 'next/link';
 import PropTypes from 'prop-types';
 import Deploy from '../vectors/deploy';
 import Done from '../vectors/done';
@@ -8,7 +7,15 @@ import Tips from './tips';
 
 let contextMessageTimeout;
 
-const Title = ({ darkMode, active, config, title, fileInput, online }) => {
+const Title = ({
+  darkMode,
+  active,
+  config,
+  title,
+  fileInput,
+  online,
+  onBackClick
+}) => {
   const [contextChanged, setContextChanged] = useState(false);
 
   const onContextChange = () => {
@@ -83,15 +90,9 @@ const Title = ({ darkMode, active, config, title, fileInput, online }) => {
           </>
         )}
         {title === 'About' && (
-          <Link
-            href={`/feed?disableScopesAnimation=1${
-              darkMode ? '&darkMode=1' : ''
-            }`}
-          >
-            <a className="close back">
-              <Back darkMode={darkMode} />
-            </a>
-          </Link>
+          <button className="close back" onClick={onBackClick}>
+            <Back darkMode={darkMode} />
+          </button>
         )}
       </div>
 
@@ -268,7 +269,8 @@ Title.propTypes = {
   config: PropTypes.object,
   contextChanged: PropTypes.bool,
   fileInput: PropTypes.object,
-  online: PropTypes.bool
+  online: PropTypes.bool,
+  onBackClick: PropTypes.func
 };
 
 export default Title;

--- a/renderer/pages/feed.js
+++ b/renderer/pages/feed.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import uid from 'uid-promise';
 import ipc from '../utils/ipc';
+import About from '../components/about-screen';
 import Title from '../components/title';
 import Switcher from '../components/switcher';
 import Events from '../components/events';
@@ -21,11 +22,18 @@ import DropZone from '../components/dropzone';
 import DeploymentBar from '../components/deployment-bar';
 
 const Main = ({ router }) => {
+  // Application states
   const [scopes, setScopes] = useState(null);
   const [active, setActive] = useState(null);
   const [darkMode, setDarkMode] = useState(router.query.darkMode || null);
   const [config, setConfig] = useState(null);
   const [online, setOnline] = useState(true);
+
+  // Navigation
+  const [isAboutVisible, setAboutVisible] = useState(false);
+  const [disableScopesAnimation, setDisableScopesAnimation] = useState(false);
+
+  // Deployments
   const [showDropZone, setShowDropZone] = useState(false);
   const [activeDeployment, setActiveDeployment] = useState(null);
   const [queuedDeployments, setQueuedDeployments] = useState([]);
@@ -204,15 +212,9 @@ const Main = ({ router }) => {
   });
 
   useEffect(() => {
-    if (router.query.disableScopesAnimation) {
-      router.replace('/feed', '/feed', { shallow: true });
-    }
-
     return aboutScreenEffect(null, () => {
-      const aboutPath = window.location.href.includes('http')
-        ? '/about'
-        : `${window.appPath}/renderer/out/about/index.html`;
-      router.replace(aboutPath);
+      setAboutVisible(true);
+      setDisableScopesAnimation(true);
     });
   });
 
@@ -296,6 +298,19 @@ const Main = ({ router }) => {
 
   const tempId = activeDeployment ? activeDeployment.tempId : null;
 
+  if (isAboutVisible) {
+    return (
+      <About
+        config={config}
+        darkMode={darkMode}
+        onBackClick={() => {
+          setAboutVisible(false);
+          setTimeout(() => setDisableScopesAnimation(false), 300);
+        }}
+      />
+    );
+  }
+
   return (
     <main>
       <div
@@ -363,6 +378,7 @@ const Main = ({ router }) => {
           active={active}
           scopes={orderedScopes}
           setConfig={setConfig}
+          disableScopesAnimation={disableScopesAnimation}
         />
       </div>
 


### PR DESCRIPTION
This PR moves `About` screen from Next.js page into a component.
This fixes a dark mode glitch and makes About screen transition in general a lot faster due to reuse of all the values