### PR TITLE
Fix login event crash in unknown regions

### DIFF
--- a/renderer/components/messages/login.js
+++ b/renderer/components/messages/login.js
@@ -46,14 +46,17 @@ export default class Login extends Message {
     if (geolocation) {
       const city =
         geolocation.city && typeof geolocation.city === 'object'
-          ? geolocation.city.names
+          ? geolocation.city && geolocation.city.names
             ? geolocation.city.names.en
-            : geolocation.city
+            : null
           : geolocation.city;
       const region =
         geolocation.most_specific_subdivision &&
         typeof geolocation.most_specific_subdivision === 'object'
-          ? geolocation.most_specific_subdivision.names.en
+          ? geolocation.most_specific_subdivision &&
+            geolocation.most_specific_subdivision.names
+            ? geolocation.most_specific_subdivision.names.en
+            : null
           : geolocation.regionName;
       if (city) {
         if (city === region) {

--- a/renderer/components/messages/message.js
+++ b/renderer/components/messages/message.js
@@ -9,7 +9,7 @@ class Message extends PureComponent {
       event.user = user;
     }
 
-    if (event.user.username) {
+    if (event.user && event.user.username) {
       return [<b key="username">{event.user.username}</b>, ' '];
     }
 


### PR DESCRIPTION
This PR fixes a login event crash when region/city are not resolved from GeoIP