### PR TITLE
Open login immediately if token isn't present

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -88,8 +88,10 @@ app.on('ready', async () => {
     // Next has failed to start but context menu should still work
   }
 
+  const config = await getConfig();
+
   // Generate the browser window
-  const window = getWindow(tray);
+  const window = getWindow(tray, config);
 
   // Provide application and the CLI with automatic updates
   autoUpdater(window);
@@ -100,7 +102,6 @@ app.on('ready', async () => {
   const toggleActivity = () => toggleWindow(tray, window);
   const { wasOpenedAtLogin } = app.getLoginItemSettings();
 
-  const config = await getConfig();
   const afterUpdate = config.desktop && config.desktop.updatedFrom;
 
   // Only allow one instance of Now running

--- a/main/window.js
+++ b/main/window.js
@@ -61,7 +61,7 @@ const attachTrayState = (win, tray) => {
   });
 };
 
-exports.getWindow = tray => {
+exports.getWindow = (tray, config) => {
   let windowHeight = 380;
 
   if (isWinOS) {
@@ -93,7 +93,7 @@ exports.getWindow = tray => {
 
   exports.positionWindow(tray, win);
 
-  loadPage(win, 'feed');
+  loadPage(win, config.token ? 'feed' : 'login');
   attachTrayState(win, tray);
 
   // Hide window if it's not focused anymore


### PR DESCRIPTION
Open window directly to `login` page if the token isn’t present in config on startup