### PR TITLE
Add native dark mode border support for macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "main/static/icons/mac.icns",
+      "darkModeSupport": true,
       "extendInfo": {
         "LSUIElement": 1
       }


### PR DESCRIPTION
> `darkModeSupport = false` Boolean - Whether a dark mode is supported. If your app does have a dark mode, you can make your app follow the system-wide dark mode setting.

https://www.electron.build/configuration/mac.html

It dims the top white line in Mojave to match native behaviour on dark mode.