### PR TITLE
Bump now-client and fix minor issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mkdirp": "0.5.1",
     "ms": "2.1.1",
     "node-fetch": "2.6.0",
-    "now-client": "4.4.0",
+    "now-client": "4.4.1",
     "path-exists": "4.0.0",
     "promisepipe": "3.0.0",
     "react-fast-compare": "2.0.4",

--- a/renderer/components/about-screen.js
+++ b/renderer/components/about-screen.js
@@ -137,7 +137,7 @@ const About = ({ darkMode, config, onBackClick }) => {
         .check-updates.disabled {
           background-color: #ccc;
           cursor: not-allowed;
-          margin-top: 2px;
+          margin-top: 5px;
           border: 1px solid transparent;
         }
 

--- a/renderer/components/event.js
+++ b/renderer/components/event.js
@@ -79,7 +79,7 @@ class Event extends React.Component {
       event.entities.find(e => e.type === 'link') ||
       event.entities.find(e => e.type === 'deployment_host');
 
-    if (linkEntity) {
+    if (linkEntity && !event.text.includes('deleted')) {
       const url = event.text.substring(linkEntity.start, linkEntity.end);
 
       this.setState({ url });
@@ -116,7 +116,7 @@ class Event extends React.Component {
       event.entities.find(e => e.type === 'link') ||
       event.entities.find(e => e.type === 'deployment_host');
 
-    if (linkEntity) {
+    if (linkEntity && !event.text.includes('deleted')) {
       id = event.text.substring(linkEntity.start, linkEntity.end);
     }
 

--- a/renderer/components/spinner.js
+++ b/renderer/components/spinner.js
@@ -29,6 +29,7 @@ const Spinner = ({
       <style jsx>
         {`
           .geist-spinner {
+            margin-top: 2px;
             height: ${width}px;
             width: ${width}px;
           }

--- a/renderer/components/spinner.js
+++ b/renderer/components/spinner.js
@@ -29,7 +29,6 @@ const Spinner = ({
       <style jsx>
         {`
           .geist-spinner {
-            margin-top: 2px;
             height: ${width}px;
             width: ${width}px;
           }

--- a/renderer/components/switcher.js
+++ b/renderer/components/switcher.js
@@ -426,6 +426,7 @@ const Switcher = ({
           overflow-y: hidden;
           padding-left: 10px;
           position: relative;
+          scroll-behavior: smooth;
         }
 
         .list-container::-webkit-scrollbar {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5966,10 +5966,10 @@ now-client@4.1.2:
     querystring "^0.2.0"
     recursive-readdir "2.2.2"
 
-now-client@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/now-client/-/now-client-4.4.0.tgz#7cdbde4052119f77200eacdedc32999a418e1c34"
-  integrity sha512-cgsMrSI6s5FW/5vyrsmSxpKYeJcmQXL6Pq4WzFVPIUHL3MLazPrcHrCXlWhA+rsTdtwzqifPGK3qdn6aQVbTww==
+now-client@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/now-client/-/now-client-4.4.1.tgz#e8711118bbcc675d7853c70dee1d4bbafcf6eaa8"
+  integrity sha512-rriIhk6cgcC91LAYLB9kxTU28Enk1H/6Q5peyPIr6aMsyS9LZd8hvQCkd8lG1EBSy5plTxqbkqbjZjJOJ5mIkg==
   dependencies:
     "@zeit/fetch" "5.1.0"
     async-retry "1.2.3"


### PR DESCRIPTION
This PR:
- Bumps `now-client` to ignore unused `now.json` properties
- Makes switcher scrolling on shadow click smooth
- Fixes updates button jitter