### PR TITLE
Adjust vertical about window layout

### DIFF
--- a/renderer/components/about-screen.js
+++ b/renderer/components/about-screen.js
@@ -35,18 +35,20 @@ const About = ({ darkMode, config, onBackClick }) => {
         <Logo darkMode={darkMode} style={{ marginBottom: 15, marginTop: 10 }} />
 
         <h1>Now</h1>
-        <h2>
-          {typeof window === 'undefined' ? '' : window.appVersion}
-          <span>
-            {checking ? (
-              <Spinner darkBg={darkMode} width={14} />
-            ) : hasLatest ? (
-              `Update available: ${latestVersion}`
-            ) : (
-              `Latest (${ago})`
-            )}
-          </span>
-        </h2>
+        <div className="version">
+          <h2>
+            {typeof window === 'undefined' ? '' : window.appVersion}
+            <span>
+              {checking ? (
+                <Spinner darkBg={darkMode} width={14} />
+              ) : hasLatest ? (
+                `Update available: ${latestVersion}`
+              ) : (
+                `Latest (${ago})`
+              )}
+            </span>
+          </h2>
+        </div>
         <button
           className={`check-updates ${checking ? 'disabled' : ''}`}
           onClick={() => {
@@ -134,10 +136,13 @@ const About = ({ darkMode, config, onBackClick }) => {
           border: 1px solid transparent;
         }
 
+        .version {
+          height: 54px;
+        }
+
         .check-updates.disabled {
           background-color: #ccc;
           cursor: not-allowed;
-          margin-top: 5px;
           border: 1px solid transparent;
         }
 


### PR DESCRIPTION
This PR adjusts the vertical layout approach in the About view to enforce section height and not rely on element margins, which should consistently fix button jitter

![Screen Recording 2019-07-03 at 4 19 02 AM 2019-07-03 04_20_09](https://user-images.githubusercontent.com/8418866/60547439-dc8e5680-9d49-11e9-9b73-b37f2281fc47.gif)
