### PR TITLE
Default to current update channel in fallback config

### DIFF
--- a/main/config.js
+++ b/main/config.js
@@ -1,9 +1,10 @@
 const path = require('path');
 const { homedir } = require('os');
-const { systemPreferences, app } = require('electron');
+const { systemPreferences } = require('electron');
 const fs = require('fs-extra');
 const groom = require('groom');
 const deepExtend = require('deep-extend');
+const pkg = require('../package.json');
 
 const paths = {
   auth: '.now/auth.json',
@@ -42,7 +43,7 @@ exports.getConfig = async () => {
   } catch (error) {
     if (error.code === 'ENOENT') {
       const newConfig = {};
-      if (app.getVersion().includes('canary')) {
+      if (pkg.version.includes('canary')) {
         newConfig.updateChannel = 'canary';
       }
 

--- a/main/config.js
+++ b/main/config.js
@@ -47,7 +47,7 @@ exports.getConfig = async () => {
       }
 
       await exports.saveConfig(newConfig, 'config');
-      await exports.saveConfig(newConfig, 'auth');
+      await exports.saveConfig({}, 'auth');
 
       return {};
     }

--- a/main/config.js
+++ b/main/config.js
@@ -50,7 +50,7 @@ exports.getConfig = async () => {
       await exports.saveConfig(newConfig, 'config');
       await exports.saveConfig({}, 'auth');
 
-      return {};
+      return newConfig;
     }
 
     throw error;

--- a/main/config.js
+++ b/main/config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { homedir } = require('os');
-const { systemPreferences } = require('electron');
+const { systemPreferences, app } = require('electron');
 const fs = require('fs-extra');
 const groom = require('groom');
 const deepExtend = require('deep-extend');
@@ -41,8 +41,13 @@ exports.getConfig = async () => {
     return assignUpdate(config || {}, { token });
   } catch (error) {
     if (error.code === 'ENOENT') {
-      await exports.saveConfig({}, 'config');
-      await exports.saveConfig({}, 'auth');
+      const newConfig = {};
+      if (app.getVersion().includes('canary')) {
+        newConfig.updateChannel = 'canary';
+      }
+
+      await exports.saveConfig(newConfig, 'config');
+      await exports.saveConfig(newConfig, 'auth');
 
       return {};
     }


### PR DESCRIPTION
This ensures that fallback config defaults the update channel to the current version type