### PR TITLE
Log out on 403

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,7 +1,13 @@
 const { ipcMain, shell, systemPreferences, dialog } = require('electron');
 const { default: createDeployment } = require('now-client');
-const { getConfig, getDarkModeStatus, saveConfig } = require('./config');
+const {
+  getConfig,
+  getDarkModeStatus,
+  saveConfig,
+  removeConfig
+} = require('./config');
 const { getMainMenu, getEventMenu } = require('./menu');
+const logout = require('./logout');
 
 module.exports = (app, tray, window) => {
   ipcMain.on('config-get-request', async event => {
@@ -105,6 +111,14 @@ module.exports = (app, tray, window) => {
 
       event.sender.send(type, { id, payload });
     }
+  });
+
+  ipcMain.on('logout-request', async () => {
+    logout().then(() => {
+      removeConfig().then(() => {
+        window.webContents.send('logged-out');
+      });
+    });
   });
 
   ipcMain.on('show-window', () => {

--- a/renderer/utils/ipc.js
+++ b/renderer/utils/ipc.js
@@ -159,6 +159,10 @@ const clearDeploymentError = invoke => {
   window.ipc.removeListener('error', invoke);
 };
 
+const logOut = () => {
+  window.ipc.send('logout-request');
+};
+
 export default {
   openURL,
   hideWindow,
@@ -192,5 +196,6 @@ export default {
   clearDeploymentReady,
   onDeploymentError,
   clearDeploymentError,
-  showWindow
+  showWindow,
+  logOut
 };

--- a/renderer/utils/load.js
+++ b/renderer/utils/load.js
@@ -1,5 +1,6 @@
 import ms from 'ms';
 import { API_REGISTRATION } from './endpoints';
+import ipc from './ipc';
 
 const NETWORK_ERR_CODE = 'network_error';
 const NETWORK_ERR_MESSAGE = 'A network error has occurred. Please retry';
@@ -31,7 +32,7 @@ export default async (path, token = null, opts = {}) => {
 
     if (res.status === 403) {
       // We need to log out here
-      return false;
+      return ipc.logOut();
     }
 
     if (res.status === 500) {


### PR DESCRIPTION
This ensures the app logs out when existing token isn’t valid