### PR TITLE
Clarify that Now Desktop is not being improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-**IMPORTANT:** Now Desktop will not be improved further (with the exception of receiving security updates).
+**IMPORTANT:** Now Desktop is no longer under active development (with the exception of receiving security updates).
 
 In turn, we recommend using [our Git Integration](https://vercel.com/import) instead or installing our [command-line interface](https://vercel.com/download) if you'd like to deploy from your terminal.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Now Desktop
 
----
 
 **IMPORTANT:** Now Desktop is no longer under active development (with the exception of receiving security updates).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **IMPORTANT:** Now Desktop is no longer under active development (with the exception of receiving security updates).
 
-In turn, we recommend using [our Git Integration](https://vercel.com/import) instead or installing our [command-line interface](https://vercel.com/download) if you'd like to deploy from your terminal.
+We recommend using [our Git Integration](https://vercel.com/import) instead, or installing our [command-line interface](https://vercel.com/download) if you'd like to deploy from your terminal.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-![](https://assets.zeit.co/image/upload/v1561730357/repositories/now-desktop/now-desktop-repo-banner.png)
+# Now Desktop
+
+---
+
+**IMPORTANT:** Now Desktop will not be improved further (with the exception of receiving security updates).
+
+In turn, we recommend using [our Git Integration](https://vercel.com/import) instead or installing our [command-line interface](https://vercel.com/download) if you'd like to deploy from your terminal.
+
+---
 
 [![macOS CI Status](https://circleci.com/gh/zeit/now-desktop.svg?style=shield)](https://circleci.com/gh/zeit/now-desktop)
 [![Windows CI status](https://dev.azure.com/zeit-builds/Now%20Desktop/_apis/build/status/now-desktop)](https://dev.azure.com/zeit-builds/Now%20Desktop/_build/latest?definitionId=1)


### PR DESCRIPTION
This ensures that everyone is aware that Now Desktop does not receive improvement updates anymore. Instead, the Git Integration or command-line interface should be installed.

[Story](https://app.clubhouse.io/vercel/story/735/clarify-that-now-desktop-does-not-receive-improvement-updates)